### PR TITLE
Update autonomy_l_french.yml

### DIFF
--- a/mod/thegreatwar/localisation/autonomy_l_french.yml
+++ b/mod/thegreatwar/localisation/autonomy_l_french.yml
@@ -1,5 +1,5 @@
 ﻿l_french:
- autonomy_dominion:0 "Dominion"
+ autonomy_dominion:0 "Protectorat"
  autonomy_colony:0 "Colonie"
  autonomy_puppet:0 "Fantoche"
  autonomy_integrated_puppet:0 "Fantoche intégré"


### PR DESCRIPTION
"Dominion" est normalement exclusivement réservé au états du commonwealth. 
"Protectorat" ne semble plus adapté pour la France