### PR TITLE
Update ww1_factions_l_french.yml

### DIFF
--- a/mod/thegreatwar/localisation/ww1_factions_l_french.yml
+++ b/mod/thegreatwar/localisation/ww1_factions_l_french.yml
@@ -1,5 +1,5 @@
 ﻿l_french:
- entente:0 "Entente"
- central_powers:0 "Empires Centraux"
+ entente:0 "Triple Entente"
+ central_powers:0 "Triplice"
  anti_bulg_league:0 "Ligue Anti-Bulgare"
  balkan_league:0 "Ligue Balkanique"


### PR DESCRIPTION
Pour moi, "Triplice" et "Triple Entente" semblent plus judicieux à utiliser, car se sont les noms aujourd'hui retenus par les historiens français.