### PR TITLE
Fix ship names - proof of concept

### DIFF
--- a/mod/thegreatwar/history/units/GER_1910.txt
+++ b/mod/thegreatwar/history/units/GER_1910.txt
@@ -1029,16 +1029,17 @@ ship = { name = "SMS D9" definition = destroyer equipment = { destroyer_1890 = {
 ship = { name = "SMS D10" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D10 Class" } } }
 
     }
-    navy = {
-        name = "1. Aufklärungsschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Blücher" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Blücher Class" } } }
-ship = { name = "SMS Dresden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
-ship = { name = "SMS Königsberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-
-}
-
+    fleet = {
+        name = Aufklärungs
+        naval_base = 241  # Wilhemshaven
+        task_force = {
+                name = "1. Aufklärungsschwadron"
+                location = 241  # Wilhemshaven
+                ship = { name = "SMS Blücher" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Blücher Class" } } }
+                ship = { name = "SMS Dresden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
+                ship = { name = "SMS Königsberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+                }
+    }
     navy = {
         name = "2. Aufklärungsschwadron"
         location = 241#Wilhelmshaven

--- a/mod/thegreatwar/history/units/GER_1910.txt
+++ b/mod/thegreatwar/history/units/GER_1910.txt
@@ -1030,52 +1030,134 @@ ship = { name = "SMS D10" definition = destroyer equipment = { destroyer_1890 = 
 
     }
     fleet = {
-        name = Aufklärungs
-        naval_base = 241  # Wilhemshaven
+        name = Hochseeflotte
+        naval_base = 241  # Wilhelmshavecn
         task_force = {
                 name = "1. Aufklärungsschwadron"
-                location = 241  # Wilhemshaven
+                location = 241  # Wilhelmshaven
                 ship = { name = "SMS Blücher" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Blücher Class" } } }
                 ship = { name = "SMS Dresden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
                 ship = { name = "SMS Königsberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-                }
-    }
-    navy = {
-        name = "2. Aufklärungsschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Mainz" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
-ship = { name = "SMS S90" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S91" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S92" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S93" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S94" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S95" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S96" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S97" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S98" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S99" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S100" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S101" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S102" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S103" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S104" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S105" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S106" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S107" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-
-    }
-    navy = {
-        name = "3. Aufklärungsschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS München" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Danzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Bremen" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Stuttgart" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-ship = { name = "SMS Hela" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Hela Class" } } }
-ship = { name = "SMS Frauenlob" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-
+         }
+         task_force = {
+                 name = "2. Aufklärungsschwadron"
+                 location = 241  # Wilhelmshaven
+                 ship = { name = "SMS Mainz" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
+                 ship = { name = "SMS S90" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S91" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S92" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S93" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S94" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S95" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S96" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S97" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S98" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S99" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S100" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S101" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S102" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S103" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S104" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S105" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S106" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S107" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+         }
+         task_force = {
+                name = "3. Aufklärungsschwadron"
+                location = 241  # Wilhelmshaven
+                ship = { name = "SMS München" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                ship = { name = "SMS Danzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                ship = { name = "SMS Bremen" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                ship = { name = "SMS Stuttgart" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+                ship = { name = "SMS Hela" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Hela Class" } } }
+                ship = { name = "SMS Frauenlob" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+         }
+         task_force = {
+                 name = "Küstenverteidigungsschwadron Weser"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Berlin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                 ship = { name = "SMS Ariadne" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS Niobe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS S114" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S115" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S116" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S117" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S118" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S119" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S120" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S121" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S122" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S123" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S124" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S125" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+         }
+         task_force = {
+                 name = "Küstenverteidigungsschwadron Elbe"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Nymphe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS Medusa" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS Bussard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Falke" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Seeadler" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Condor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Cormoran" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Geier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS S126" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S127" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S128" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S129" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S130" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S131" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS G132" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G133" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G134" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G135" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G136" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+         }
+         task_force = {
+                 name = "1. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Nassau" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Westfalen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+         }
+         task_force = {
+                 name = "2. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Deutschland" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Hessen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Hannover" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Pommern" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Schlesien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Schleswig-Holstein" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Braunschweig" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Elsaß" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Lothringen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+         }
+         task_force = {
+                 name = "4. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Wittelsbach" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Wettin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Zähringen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Schwaben" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Mecklenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+         }
+         task_force = {
+                 name = "5. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Wörth" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Weissenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Kaiser Friedrich III" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Wilhelm II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Wilhelm der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Karl der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kurfürst Friedrich Wilhelm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Brandenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Württemberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Sachsen Class" } } }
+                 ship = { name = "SMS Oldenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Oldenburg Class" } } }
+         }
     }
     navy = {
         name = "4. Aufklärungsschwadron"
@@ -1085,7 +1167,6 @@ ship = { name = "SMS Roon" definition = heavy_cruiser equipment = { heavy_cruise
 ship = { name = "SMS Yorck" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
 ship = { name = "SMS Prinz Heinrich" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Prinz Heinrich Class" } } }
 ship = { name = "SMS Prinz Adalbert" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
-
     }
     navy = {
         name = "5. Aufklärungsschwadron"
@@ -1101,104 +1182,6 @@ ship = { name = "SMS G110" definition = destroyer equipment = { destroyer_1900 =
 ship = { name = "SMS G111" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
 ship = { name = "SMS G112" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
 ship = { name = "SMS G113" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "Küstenverteidigungsschwadron Weser"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Berlin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Ariadne" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Niobe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS S114" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S115" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S116" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S117" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S118" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S119" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S120" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S121" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S122" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S123" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S124" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S125" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-
-    }
-    navy = {
-        name = "Küstenverteidigungsschwadron Elbe"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Nymphe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Medusa" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Bussard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Falke" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Seeadler" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Condor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Cormoran" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Geier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS S126" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S127" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S128" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S129" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S130" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S131" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS G132" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G133" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G134" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G135" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G136" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-
-    }
-    navy = {
-        name = "1. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Nassau" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Westfalen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "2. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Deutschland" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Hessen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Hannover" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Pommern" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Schlesien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Schleswig-Holstein" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Braunschweig" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Elsaß" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Lothringen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "4. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Wittelsbach" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Wettin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Zähringen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Schwaben" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Mecklenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-
-    }
-    navy = {
-        name = "5. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Wörth" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-ship = { name = "SMS Weissenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-ship = { name = "SMS Kaiser Friedrich III" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Wilhelm II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Wilhelm der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Karl der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kurfürst Friedrich Wilhelm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-ship = { name = "SMS Brandenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Württemberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Sachsen Class" } } }
-ship = { name = "SMS Oldenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Oldenburg Class" } } }
 
     }
     navy = {


### PR DESCRIPTION
### **Problem:**
https://github.com/Wolferos/Hearts-of-Iron-IV-The-Great-War/issues/199 Ship and fleet names aren't appearing. It appears this is due to not updating tags that were introduced in the man the guns dlc.
![image](https://user-images.githubusercontent.com/4251684/68094775-60c42800-fe69-11e9-9b6e-64199c06cf5f.png)
![image](https://user-images.githubusercontent.com/4251684/68094787-746f8e80-fe69-11e9-9245-c65faa98759a.png)


### **Solution:**
Update tags. In the image below, you'll see that the fleet name appears, and that the ships show as a fleet and task force in the navy sidebar.
![image](https://user-images.githubusercontent.com/4251684/68094697-b8ae5f00-fe68-11e9-9acc-dfbb5ee69dd9.png)

![image](https://user-images.githubusercontent.com/4251684/68094707-ce238900-fe68-11e9-9e72-448badf2c8c6.png)

This small batch of changes is just a proof of concept. Updating ALL the ships will obviously be a fairly involved process and a huge diff. Wanted to make sure @Wolferos is cool with this first.

### **Testing:**
Load the mod as Germany in 1910, and verify the ships located in Wilhelmshaven have their names updated are in the Hochseeflotte.

