### PR TITLE
Fix Ship Organization and Names

### DIFF
--- a/mod/thegreatwar/history/units/ARG_1910.txt
+++ b/mod/thegreatwar/history/units/ARG_1910.txt
@@ -33,6 +33,32 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada Argentina Fleet"
+	naval_base = 12364 # Buenos Aires
+	task_force = {
+		name = "Armada Argentina"
+		location = 12364 # Buenos Aires
+		ship = { name = "ARA La Plata" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Los Andes" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Almirante Brown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Almirante Brown Class" } } }
+		ship = { name = "ARA Independencia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
+		ship = { name = "ARA Libertad" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
+		ship = { name = "ARA Patagonia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Veinticinco de Mayo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "25 De Mayo Class" } } }
+		ship = { name = "ARA Nueve de Julio" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "9 De Julio Class" } } }
+		ship = { name = "ARA Buenos Aires" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General Belgrano" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General Pueyrredón" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General San Martín" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Corrientes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Entre Rios" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Misiones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
+	}
+}
+
 	division= { 
 			name = "1a División de Infantería"
 			location = 5173 # Río Gallegos
@@ -71,29 +97,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Armada Argentina"
-		location=12364 # Buenos Aires
-		base=12364 # Buenos Aires
-ship = { name = "ARA La Plata" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Los Andes" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Almirante Brown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Almirante Brown Class" } } }
-ship = { name = "ARA Independencia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
-ship = { name = "ARA Libertad" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
-ship = { name = "ARA Patagonia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Veinticinco de Mayo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "25 De Mayo Class" } } }
-ship = { name = "ARA Nueve de Julio" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "9 De Julio Class" } } }
-ship = { name = "ARA Buenos Aires" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General Belgrano" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General Pueyrredón" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General San Martín" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Corrientes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Entre Rios" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Misiones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
-
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/ARG_1914.txt
+++ b/mod/thegreatwar/history/units/ARG_1914.txt
@@ -33,6 +33,40 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada Argentina Fleet"
+	naval_base = 12364 # Buenos Aires
+	task_force = {
+		name = "Armada Argentina"
+		location = 12364 # Buenos Aires
+		ship = { name = "ARA La Plata" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Los Andes" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Almirante Brown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Almirante Brown Class" } } }
+		ship = { name = "ARA Independencia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
+		ship = { name = "ARA Libertad" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
+		ship = { name = "ARA Patagonia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Veinticinco de Mayo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "25 De Mayo Class" } } }
+		ship = { name = "ARA Nueve de Julio" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "9 De Julio Class" } } }
+		ship = { name = "ARA Buenos Aires" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General Belgrano" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General Pueyrredón" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA General San Martín" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Corrientes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Entre Rios" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Misiones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Catamarca" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Jujuy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA La Plata" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Cordoba" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA San Luis" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Santa Fe" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Tucuman" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
+		ship = { name = "ARA Santiago" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
+	}
+}
+
 	division= { 
 			name = "1a División de Infantería"
 			location = 5173 # Río Gallegos
@@ -71,37 +105,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Armada Argentina"
-		location=12364 # Buenos Aires
-		base=12364 # Buenos Aires
-ship = { name = "ARA La Plata" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Los Andes" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Almirante Brown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Almirante Brown Class" } } }
-ship = { name = "ARA Independencia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
-ship = { name = "ARA Libertad" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ARG version_name = "Libertad Class" } } }
-ship = { name = "ARA Patagonia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Veinticinco de Mayo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "25 De Mayo Class" } } }
-ship = { name = "ARA Nueve de Julio" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ARG version_name = "9 De Julio Class" } } }
-ship = { name = "ARA Buenos Aires" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General Belgrano" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General Pueyrredón" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA General San Martín" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Corrientes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Entre Rios" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Misiones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Catamarca" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Jujuy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA La Plata" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Cordoba" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA San Luis" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Santa Fe" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Tucuman" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
-ship = { name = "ARA Santiago" definition = destroyer equipment = { destroyer_1914 = { amount = 1 owner = ARG } } }
-
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/AST_1910.txt
+++ b/mod/thegreatwar/history/units/AST_1910.txt
@@ -33,6 +33,18 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Royal Australian Navy Fleet"
+	naval_base = 12406 # Sydney
+	task_force = {
+		name = "Royal Australian Navy"
+		location = 12406 # Sydney
+		ship = { name = "HMAS Encounter" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMAS Pioneer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st Australian Division"
 			location=7798 # Melbourne
@@ -47,15 +59,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Royal Australian Navy"
-		location=12406 # Sydney
-		base=12406 # Sydney
-
-ship = { name = "HMAS Encounter" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-ship = { name = "HMAS Pioneer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/AST_1914.txt
+++ b/mod/thegreatwar/history/units/AST_1914.txt
@@ -33,6 +33,21 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Royal Australian Navy Fleet"
+	naval_base = 12406 # Sydney
+	task_force = {
+		name = "Royal Australian Navy"
+		location = 12406 # Sydney
+		ship = { name = "HMS Australia" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Sydney" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
+		ship = { name = "HMS Melbourne" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
+		ship = { name = "HMS Encounter" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMS Pioneer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st Australian Division"
 			location=7798 # Melbourne
@@ -103,16 +118,7 @@ units = {
 			# start_equipment_factor = 0.3 
 			# start_manpower_factor = 0.3
 			}
-	 navy = {
-		name = "Royal Australian Navy"
-		location=12406 # Sydney
-		base=12406 # Sydney
-ship = { name = "HMS Australia" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Sydney" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
-ship = { name = "HMS Melbourne" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
-ship = { name = "HMS Encounter" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-ship = { name = "HMS Pioneer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/AUH_1910.txt
+++ b/mod/thegreatwar/history/units/AUH_1910.txt
@@ -112,6 +112,95 @@ division_template = {
 
 units = {
 
+fleet = {
+	name = "1. Linienschiffschwadron Fleet"
+	naval_base = 11735 # Pola
+	task_force = {
+		name = "1. Linienschiffschwadron"
+		location = 11735 # Pola
+		ship = { name = "SMS Kronprinzessin Erzherzogin Stephanie" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Kronprinz Erzherzogin Rudolf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Kronprinz Erzherzogin Rudolf Class" } } }
+		ship = { name = "SMS Meteor" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Blitz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Komet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Planet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Trabant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Satellit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Magnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Ulan" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Streiter" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Wildfang" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Scharfschütze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "2. Linienschiffschwadron"
+		location = 11735 # Pola
+		ship = { name = "SMS Habsburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
+		ship = { name = "SMS Árpád" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
+		ship = { name = "SMS Babenberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
+		ship = { name = "SMS Erzherzog Karl" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Erzherzog Friedrich" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Erzherzog Ferdinand Max" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Uskoke" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Turul" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Pandur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Csikos" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Reka" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Dinara" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Velebit" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "3. Linienschiffschwadron"
+		location = 11735 # Pola
+		ship = { name = "SMS Monarch" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
+		ship = { name = "SMS Wien" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
+		ship = { name = "SMS Budapest" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
+		ship = { name = "SMS Kaiserin und Königin Maria Theresia" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "1. Kreuzerdivision"
+		location = 11735 # Pola
+		ship = { name = "SMS Kaiser Karl VI" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Zenta" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Kaiser Franz Joseph I" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
+		ship = { name = "SMS Panther" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
+		ship = { name = "SMS Leopard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
+		ship = { name = "SMS Tiger" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Tiger Class" } } }
+		ship = { name = "SMS Zara" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Spalato" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Sebenico" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Lussin" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "2. Kreuzerdivision"
+		location = 11735 # Pola
+		ship = { name = "SMS Sankt Georg" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH version_name = "Sankt Georg Class" } } }
+		ship = { name = "SMS Aspern" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Szigetvár" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "U-bootdivision"
+		location = 11735 # Pola
+		ship = { name = "SMS SM U-1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS SM U-2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS SM U-3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
+		ship = { name = "SMS SM U-4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
+		ship = { name = "SMS SM U-5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS SM U-6" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
+	}
+}
+
+fleet = {
+	name = "Chinastation Fleet"
+	naval_base = 5246 # Qingdao
+	task_force = {
+		name = "Chinastation"
+		location = 5246 # Qingdao
+		ship = { name = "SMS Kaiserin Elisabeth" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
+	}
+}
+
+
 division= { 
 name = "105. LstrInfanteriebrigaden"
 location = 9630 # Lienz
@@ -612,102 +701,13 @@ start_experience_factor=0.1
 
 ############################################################################################
 
- navy = {
-name = "1. Linienschiffschwadron"
-location = 11735 # Pola
-base =  11735 # Pola
-ship = { name = "SMS Kronprinzessin Erzherzogin Stephanie" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Kronprinz Erzherzogin Rudolf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Kronprinz Erzherzogin Rudolf Class" } } }
-ship = { name = "SMS Meteor" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Blitz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Komet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Planet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Trabant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Satellit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Magnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Ulan" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Streiter" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Wildfang" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Scharfschütze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-
-
-}
- navy = {
-name = "2. Linienschiffschwadron"
-location = 11735 # Pola
-base =  11735 # Pola
-ship = { name = "SMS Habsburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
-ship = { name = "SMS Árpád" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
-ship = { name = "SMS Babenberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
-ship = { name = "SMS Erzherzog Karl" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Erzherzog Friedrich" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Erzherzog Ferdinand Max" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Uskoke" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Turul" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Pandur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Csikos" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Reka" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Dinara" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Velebit" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-
-}
- navy = {
-name = "3. Linienschiffschwadron"
-location = 11735 # Pola
-base =  11735 # Pola
-ship = { name = "SMS Monarch" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
-ship = { name = "SMS Wien" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
-ship = { name = "SMS Budapest" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
-ship = { name = "SMS Kaiserin und Königin Maria Theresia" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = AUH } } }
-
-
-}
- navy = {
-name = "1. Kreuzerdivision"
-location = 11735 # Pola
-base =  11735 # Pola
-ship = { name = "SMS Kaiser Karl VI" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Zenta" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Kaiser Franz Joseph I" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
-ship = { name = "SMS Panther" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
-ship = { name = "SMS Leopard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
-ship = { name = "SMS Tiger" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Tiger Class" } } }
-ship = { name = "SMS Zara" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Spalato" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Sebenico" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Lussin" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-
-
-}
- navy = {
-name = "2. Kreuzerdivision"
-location = 11735 # Pola
-base =  11735 # Pola
-ship = { name = "SMS Sankt Georg" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH version_name = "Sankt Georg Class" } } }
-ship = { name = "SMS Aspern" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Szigetvár" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
-
-
-}
- navy = {
-name = "Chinastation"
-location = 5246  # Qingdao
-base =  5246  # Qingdao
-ship = { name = "SMS Kaiserin Elisabeth" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
-
-
-}
- navy = {
-name = "U-bootdivision"
-location = 11735 # Pola
-base =  11735 # Pola
-ship = { name = "SMS SM U-1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS SM U-2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS SM U-3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
-ship = { name = "SMS SM U-4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
-ship = { name = "SMS SM U-5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS SM U-6" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
-}
+ 
+ 
+ 
+ 
+ 
+ 
+ 
 
 }
 

--- a/mod/thegreatwar/history/units/AUH_1914.txt
+++ b/mod/thegreatwar/history/units/AUH_1914.txt
@@ -110,6 +110,113 @@ division_template = {
 
 
 units = {
+
+fleet = {
+	name = "Chinastation Fleet"
+	naval_base = 10000 # Qingdao
+	task_force = {
+		name = "Chinastation"
+		location = 10000 # Qingdao
+		ship = { name = "SMS Kaiserin Elisabeth" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
+	}
+}
+
+fleet = {
+	name = "2. Linienschiffschwadron Fleet"
+	naval_base = 11735 # Pola
+	task_force = {
+		name = "Flottenflaggschiff"
+		location = 11735 # Pola
+		ship = { name = "SMS Viribus Unitis" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "1. Linienschiffschwadron"
+		location = 11735 # Pola
+		ship = { name = "SMS Erzherzog Franz Ferdinand" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH version_name = "Radetzky Class" } } }
+		ship = { name = "SMS Radetzky" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH version_name = "Radetzky Class" } } }
+		ship = { name = "SMS Zristi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH version_name = "Radetzky Class" } } }
+		ship = { name = "SMS Tegetthoff" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Turul" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Pandur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Csikos" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Reka" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Dinara" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Velebit" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Tátra" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Balaton" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Csepel" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Lika" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Triglav" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Orjen" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "2. Linienschiffschwadron"
+		location = 11735 # Pola
+		ship = { name = "SMS Erzherzog Karl" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Erzherzog Friedrich" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Erzherzog Ferdinand Max" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Habsburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
+		ship = { name = "SMS Árpád" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
+		ship = { name = "SMS Babenberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
+		ship = { name = "SMS Meteor" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Blitz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Komet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Planet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Trabant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Satellit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Magnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
+		ship = { name = "SMS Ulan" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Streiter" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Wildfang" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Scharfschütze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Uskoke" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Huszar II" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "3. Linienschiffschwadron"
+		location = 11735 # Pola
+		ship = { name = "SMS Kronprinzessin Erzherzogin Stephanie" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Kronprinz Erzherzogin Rudolf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Kronprinz Erzherzogin Rudolf Class" } } }
+		ship = { name = "SMS Monarch" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
+		ship = { name = "SMS Wien" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
+		ship = { name = "SMS Budapest" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
+		ship = { name = "SMS Kaiserin und Königin Maria Theresia" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "1. Kreuzerdivision"
+		location = 11735 # Pola
+		ship = { name = "SMS Kaiser Karl VI" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Zenta" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Kaiser Franz Joseph I" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
+		ship = { name = "SMS Panther" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
+		ship = { name = "SMS Leopard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
+		ship = { name = "SMS Tiger" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Tiger Class" } } }
+		ship = { name = "SMS Zara" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Spalato" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Sebenico" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Lussin" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "2. Kreuzerdivision"
+		location = 11735 # Pola
+		ship = { name = "SMS Sankt Georg" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH version_name = "Sankt Georg Class" } } }
+		ship = { name = "SMS Aspern" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Szigetvár" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS Admiral Spaun" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = AUH } } }
+	}
+	task_force = {
+		name = "U-bootdivision"
+		location = 11735 # Pola
+		ship = { name = "SMS SM U-1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS SM U-2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS SM U-3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
+		ship = { name = "SMS SM U-4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
+		ship = { name = "SMS SM U-5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS SM U-6" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
+		ship = { name = "SMS SM U-12" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
+	}
+}
+
 	division= { 
 			name = "105. LstrInfanteriebrigaden"
 			location = 9630 # Lienz
@@ -765,122 +872,14 @@ units = {
 			start_experience_factor=0.1
 			}
 			######################################
-	 navy = {
-		name = "Flottenflaggschiff"
-		location = 11735 # Pola
-		base =  11735 # Pola
-ship = { name = "SMS Viribus Unitis" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = AUH } } }
-
-		}
-	 navy = {
-		name = "1. Linienschiffschwadron"
-		location = 11735 # Pola
-		base =  11735 # Pola
-ship = { name = "SMS Erzherzog Franz Ferdinand" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH version_name = "Radetzky Class" } } }
-ship = { name = "SMS Radetzky" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH version_name = "Radetzky Class" } } }
-ship = { name = "SMS Zristi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH version_name = "Radetzky Class" } } }
-ship = { name = "SMS Tegetthoff" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Turul" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Pandur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Csikos" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Reka" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Dinara" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Velebit" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Tátra" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Balaton" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Csepel" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Lika" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Triglav" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Orjen" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = AUH } } }
-
-
-		}
-	 navy = {
-		name = "2. Linienschiffschwadron"
-		location = 11735 # Pola
-		base =  11735 # Pola
-		
-ship = { name = "SMS Erzherzog Karl" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Erzherzog Friedrich" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Erzherzog Ferdinand Max" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Habsburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
-ship = { name = "SMS Árpád" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
-ship = { name = "SMS Babenberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Habsburg Class" } } }
-ship = { name = "SMS Meteor" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Blitz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Komet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Planet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Trabant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Satellit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Magnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = AUH version_name = "Blitz Class" } } }
-ship = { name = "SMS Ulan" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Streiter" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Wildfang" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Scharfschütze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Uskoke" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Huszar II" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = AUH } } }
-
-		}
-	 navy = {
-		name = "3. Linienschiffschwadron"
-		location = 11735 # Pola
-		base =  11735 # Pola
-ship = { name = "SMS Kronprinzessin Erzherzogin Stephanie" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Kronprinz Erzherzogin Rudolf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Kronprinz Erzherzogin Rudolf Class" } } }
-ship = { name = "SMS Monarch" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
-ship = { name = "SMS Wien" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
-ship = { name = "SMS Budapest" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = AUH version_name = "Monarch Class" } } }
-ship = { name = "SMS Kaiserin und Königin Maria Theresia" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = AUH } } }
-
-		}
-	 navy = {
-		name = "1. Kreuzerdivision"
-		location = 11735 # Pola
-		base =  11735 # Pola
-ship = { name = "SMS Kaiser Karl VI" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Zenta" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Kaiser Franz Joseph I" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
-ship = { name = "SMS Panther" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
-ship = { name = "SMS Leopard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Panther Class" } } }
-ship = { name = "SMS Tiger" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Tiger Class" } } }
-ship = { name = "SMS Zara" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Spalato" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Sebenico" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Lussin" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH } } }
-
-
-		}
-	 navy = {
-		name = "2. Kreuzerdivision"
-		location = 11735 # Pola
-		base =  11735 # Pola
-ship = { name = "SMS Sankt Georg" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = AUH version_name = "Sankt Georg Class" } } }
-ship = { name = "SMS Aspern" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Szigetvár" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS Admiral Spaun" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = AUH } } }
-
-
-		}
-	 navy = {
-		name = "U-bootdivision"
-		location = 11735 # Pola
-		base =  11735 # Pola
-ship = { name = "SMS SM U-1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS SM U-2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS SM U-3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
-ship = { name = "SMS SM U-4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = AUH version_name = "U3 Class" } } }
-ship = { name = "SMS SM U-5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS SM U-6" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
-ship = { name = "SMS SM U-12" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = AUH } } }
-
-
-		}
-	 navy = {
-		name = "Chinastation"
-		location=10000 # Qingdao
-		base=10000 # Qingdao
-ship = { name = "SMS Kaiserin Elisabeth" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = AUH version_name = "Kaiser Franz Joseph I Class" } } }
-		}
+	 
+	 
+	 
+	 
+	 
+	 
+	 
+	 
 	}
 air_wings = { 
 	4 = { # Wien "Luftfahrtruppen"

--- a/mod/thegreatwar/history/units/BRA_1910.txt
+++ b/mod/thegreatwar/history/units/BRA_1910.txt
@@ -32,6 +32,39 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Marinha do Brasil Fleet"
+	naval_base = 10980 # Rio de Janeiro
+	task_force = {
+		name = "Marinha do Brasil"
+		location = 10980 # Rio de Janeiro
+		ship = { name = "Marshal Deodoro" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "Marshal Floriano" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "Minas Geraes" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Almirante Tamandare" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = BRA version_name = "Almirante Tamandare Class" } } }
+		ship = { name = "Benjamin Constant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Republica Class" } } }
+		ship = { name = "Almirante Barroso" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Barrozo Class" } } }
+		ship = { name = "Bahia" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Rio Grande Do Sul" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Tiradentes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA } } }
+		ship = { name = "Gustavo Sampaio" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Gustavo Sampaio Class" } } }
+		ship = { name = "Tupi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
+		ship = { name = "Timbira" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
+		ship = { name = "Tamoio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "Para" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Piaui" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Amazonas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Mato Grosso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Rio Grande Do Norte" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Paraiba" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Alagoas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Santa Catharina" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Parana" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+	}
+}
+
 	division= { 
 			name = "1a Divisão de Infantaria"
 			location=12853 # Belém
@@ -78,35 +111,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Marinha do Brasil"
-		location=10980 # Rio de Janeiro
-		base=10980 # Rio de Janeiro
-ship = { name = "Marshal Deodoro" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
-ship = { name = "Marshal Floriano" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
-ship = { name = "Minas Geraes" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Almirante Tamandare" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = BRA version_name = "Almirante Tamandare Class" } } }
-ship = { name = "Benjamin Constant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA } } }
-ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Republica Class" } } }
-ship = { name = "Almirante Barroso" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Barrozo Class" } } }
-ship = { name = "Bahia" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Rio Grande Do Sul" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Tiradentes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA } } }
-ship = { name = "Gustavo Sampaio" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Gustavo Sampaio Class" } } }
-ship = { name = "Tupi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
-ship = { name = "Timbira" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
-ship = { name = "Tamoio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BRA } } }
-ship = { name = "Para" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Piaui" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Amazonas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Mato Grosso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Rio Grande Do Norte" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Paraiba" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Alagoas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Santa Catharina" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-ship = { name = "Parana" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-
-	}
+	 
 }
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/BRA_1914.txt
+++ b/mod/thegreatwar/history/units/BRA_1914.txt
@@ -33,6 +33,43 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Marinha do Brasil Fleet"
+	naval_base = 10980 # Rio de Janeiro
+	task_force = {
+		name = "Marinha do Brasil"
+		location = 10980 # Rio de Janeiro
+		ship = { name = "Marshal Deodoro" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "Marshal Floriano" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "Minas Geraes" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "São Paulo" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Almirante Tamandare" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = BRA version_name = "Almirante Tamandare Class" } } }
+		ship = { name = "Benjamin Constant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Republica Class" } } }
+		ship = { name = "Almirante Barroso" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Barrozo Class" } } }
+		ship = { name = "Bahia" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Rio Grande Do Sul" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Tiradentes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA } } }
+		ship = { name = "Tupi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
+		ship = { name = "Timbira" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
+		ship = { name = "Tamoio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BRA } } }
+		ship = { name = "Para" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Piaui" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Amazonas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Mato Grosso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Rio Grande Do Norte" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Paraiba" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Alagoas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Santa Catharina" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Parana" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "Sergipe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
+		ship = { name = "F1" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = BRA } } }
+		ship = { name = "F3" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = BRA } } }
+		ship = { name = "F5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = BRA } } }
+	}
+}
+
 	division= { 
 			name = "1a Divisão de Infantaria"
 			location=12853 # Belém
@@ -95,40 +132,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Marinha do Brasil"
-		location=10980 # Rio de Janeiro
-		base=10980 # Rio de Janeiro
-		ship = { name = "Marshal Deodoro" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
-		ship = { name = "Marshal Floriano" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = BRA } } }
-		ship = { name = "Minas Geraes" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "São Paulo" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Almirante Tamandare" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = BRA version_name = "Almirante Tamandare Class" } } }
-		ship = { name = "Benjamin Constant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA } } }
-		ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Republica Class" } } }
-		ship = { name = "Almirante Barroso" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = BRA version_name = "Barrozo Class" } } }
-		ship = { name = "Bahia" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Rio Grande Do Sul" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Tiradentes" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA } } }
-		ship = { name = "Tupi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
-		ship = { name = "Timbira" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BRA version_name = "Tupi Class" } } }
-		ship = { name = "Tamoio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BRA } } }
-		ship = { name = "Para" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Piaui" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Amazonas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Mato Grosso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Rio Grande Do Norte" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Paraiba" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Alagoas" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Santa Catharina" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Parana" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		ship = { name = "Sergipe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = BRA } } }
-		# ship = { name = "F1" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = BRA } } }
-		# ship = { name = "F3" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = BRA } } }
-		# ship = { name = "F5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = BRA } } }
-
-	
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/BUL_1910.txt
+++ b/mod/thegreatwar/history/units/BUL_1910.txt
@@ -38,6 +38,23 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "1st Fleet Fleet"
+	naval_base = 9783
+	task_force = {
+		name = "1st Fleet"
+		location = 9783
+		ship = { name = "Nadezhda" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BUL } } }
+		ship = { name = "1. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "2. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "3. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "4. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "5. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "6. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+	}
+}
+
 	division= { 
 			name = "4-a Konna brigada"
 			location=9783 # Varna
@@ -195,18 +212,7 @@ units = {
 			# start_manpower_factor = 0.3
 			}
 
-		navy = {
-			name = "1st Fleet"
-			location = 9783
-			base =  9783
-			ship = { name = "Nadezhda" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BUL } } }
-			ship = { name = "1. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "2. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "3. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "4. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "5. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "6. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-		}
+		
 	}
 
 air_wings = { 

--- a/mod/thegreatwar/history/units/BUL_1914.txt
+++ b/mod/thegreatwar/history/units/BUL_1914.txt
@@ -38,6 +38,23 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "1st Fleet Fleet"
+	naval_base = 9783
+	task_force = {
+		name = "1st Fleet"
+		location = 9783
+		ship = { name = "Nadezhda" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BUL } } }
+		ship = { name = "1. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "2. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "3. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "4. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "5. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+		ship = { name = "6. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
+	}
+}
+
 	division= { 
 			name = "4-a Konna brigada"
 			location=9783 # Varna
@@ -195,18 +212,7 @@ units = {
 			# start_manpower_factor = 0.3
 			}
 
-		navy = {
-			name = "1st Fleet"
-			location = 9783
-			base =  9783
-			ship = { name = "Nadezhda" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = BUL } } }
-			ship = { name = "1. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "2. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "3. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "4. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "5. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-			ship = { name = "6. Torpedo Boat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = BUL } } }
-		}
+		
 
 	}
 air_wings = { 

--- a/mod/thegreatwar/history/units/CAN_1910.txt
+++ b/mod/thegreatwar/history/units/CAN_1910.txt
@@ -33,6 +33,18 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Royal Canadian Navy Fleet"
+	naval_base = 7361 # Halifax
+	task_force = {
+		name = "Royal Canadian Navy"
+		location = 7361 # Halifax
+		ship = { name = "HMS Niobe" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Rainbow" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st Canadian Infantry Div."
 			location=3778 # Ottawa
@@ -47,15 +59,7 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Royal Canadian Navy"
-		location=7361 # Halifax
-		base=7361 # Halifax
-ship = { name = "HMS Niobe" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Rainbow" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/CAN_1914.txt
+++ b/mod/thegreatwar/history/units/CAN_1914.txt
@@ -33,6 +33,19 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Royal Canadian Navy Fleet"
+	naval_base = 7361 # Halifax
+	task_force = {
+		name = "Royal Canadian Navy"
+		location = 7361 # Halifax
+		ship = { name = "HMS Rainbow" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Niobe" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "Destroyer Flotilla 1" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CAN } } }
+	}
+}
+
 	division= { 
 			name = "1st Canadian Infantry Div."
 			location=3778 # Ottawa
@@ -47,16 +60,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Royal Canadian Navy"
-		location=7361 # Halifax
-		base=7361 # Halifax
-ship = { name = "HMS Rainbow" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Niobe" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-
-
-		 #ship = { name = "Destroyer Flotilla 1" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CAN } } } #type = destroyer  historical_model = 9 
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/CHI_1914.txt
+++ b/mod/thegreatwar/history/units/CHI_1914.txt
@@ -33,6 +33,59 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Northern Fleet Fleet"
+	naval_base = 10068 # Tianjin
+	task_force = {
+		name = "Northern Fleet"
+		location = 10068 # Tianjin
+		ship = { name = "Hai Chou" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Yung Class" } } }
+		ship = { name = "Chao Ho" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = CHI } } }
+		ship = { name = "Chen Hang" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Hai Ching Class" } } }
+		ship = { name = "Nan Jui" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Nan Tan Class" } } }
+		ship = { name = "Pao Min" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Pao Min Class" } } }
+		ship = { name = "Fei Hung" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = CHI } } }
+		ship = { name = "Chao Wu" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI } } }
+		ship = { name = "Fu Po" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
+		ship = { name = "Teng Ying Chou" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
+		ship = { name = "Tai An" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
+		ship = { name = "Yuan Kai" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
+		ship = { name = "Chang Feng" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = CHI } } }
+		ship = { name = "Fu Po" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = CHI } } }
+		ship = { name = "Fei Hung" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = CHI } } }
+		ship = { name = "Hu Peng" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
+		ship = { name = "Hu Ngo" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
+		ship = { name = "Hu Chung" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
+		ship = { name = "Hu Ying" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
+	}
+}
+
+fleet = {
+	name = "Central Fleet Fleet"
+	naval_base = 9974 # Ningbo
+	task_force = {
+		name = "Central Fleet"
+		location = 9974 # Ningbo
+		ship = { name = "Hai Tan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Yung Class" } } }
+		ship = { name = "Hai Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Tien Class" } } }
+		ship = { name = "King Ching" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI } } }
+		ship = { name = "Tung Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Tung Chi Class" } } }
+	}
+}
+
+fleet = {
+	name = "Southern Fleet Fleet"
+	naval_base = 1047 # Guangzhou
+	task_force = {
+		name = "Southern Fleet"
+		location = 1047 # Guangzhou
+		ship = { name = "Ying Swei" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = CHI } } }
+		ship = { name = "Fu An" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Tung Chi Class" } } }
+		ship = { name = "Hai Yung" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Yung Class" } } }
+	}
+}
+
 	division= { 
 			name = "1. Jun"
 			location=11913 # Nanjing
@@ -367,60 +420,9 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Northern Fleet"
-		location=10068 # Tianjin
-		base=10068 # Tianjin
-
-ship = { name = "Hai Chou" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Yung Class" } } }
-ship = { name = "Chao Ho" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = CHI } } }
-
-
-ship = { name = "Chen Hang" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Hai Ching Class" } } }
-ship = { name = "Nan Jui" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Nan Tan Class" } } }
-ship = { name = "Pao Min" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Pao Min Class" } } }
-
-ship = { name = "Fei Hung" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = CHI } } }
-ship = { name = "Chao Wu" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI } } }
-
-ship = { name = "Fu Po" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
-ship = { name = "Teng Ying Chou" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
-ship = { name = "Tai An" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
-ship = { name = "Yuan Kai" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHI version_name = "Fu Po Class" } } }
-
-
-
-ship = { name = "Chang Feng" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = CHI } } }
-ship = { name = "Fu Po" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = CHI } } }
-ship = { name = "Fei Hung" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = CHI } } }
-ship = { name = "Hu Peng" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
-ship = { name = "Hu Ngo" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
-ship = { name = "Hu Chung" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
-ship = { name = "Hu Ying" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHI } } }
-
-
-
-		}
-	 navy = {
-		name = "Central Fleet"
-		location = 9974 # Ningbo
-		base =  9974 # Ningbo
-ship = { name = "Hai Tan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Yung Class" } } }
-ship = { name = "Hai Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Tien Class" } } }
-ship = { name = "King Ching" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI } } }
-ship = { name = "Tung Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Tung Chi Class" } } }
-
-
-		}
-	 navy = {
-		name = "Southern Fleet"
-		location=1047 # Guangzhou
-		base=1047 # Guangzhou
-ship = { name = "Ying Swei" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = CHI } } }
-ship = { name = "Fu An" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Tung Chi Class" } } }
-ship = { name = "Hai Yung" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHI version_name = "Hai Yung Class" } } }
-
-		}
+	 
+	 
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/CHL_1910.txt
+++ b/mod/thegreatwar/history/units/CHL_1910.txt
@@ -33,6 +33,34 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Chilean Fleet Fleet"
+	naval_base = 8222 # Santiago
+	task_force = {
+		name = "Chilean Fleet"
+		location = 8222 # Santiago
+		ship = { name = "Huascar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Almirante Cochrane" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Almirante Cochrane Class" } } }
+		ship = { name = "Capitan Prat" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Capitan Prat Class" } } }
+		ship = { name = "Esmeralda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "O'Higgins" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL version_name = "O'Higgins Class" } } }
+		ship = { name = "Presidente Errauriz" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Blanco Encalada" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Blanco Encalada Class" } } }
+		ship = { name = "Ministro Zenteno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Ministro Zenteno Class" } } }
+		ship = { name = "Chacabuco" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHL } } }
+		ship = { name = "Almirante Lynch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Almirante Condell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Capitan Orella" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Capitan Munez Gamero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Teniente Serrano" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Guardia-Marina Riquelme" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Capitan Merino Jarpa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
+		ship = { name = "Capitan O'Brien" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
+		ship = { name = "Capitan Thompson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL version_name = "Capitan Thompson Class" } } }
+	}
+}
+
 	division= { 
 			name = "1. División de Infantería"
 			location=650 # Santiago
@@ -63,31 +91,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0.15
 			}
-	 navy = {
-		name = "Chilean Fleet"
-		location=8222 # Santiago
-		base=8222 # Santiago
-ship = { name = "Huascar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Almirante Cochrane" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Almirante Cochrane Class" } } }
-ship = { name = "Capitan Prat" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Capitan Prat Class" } } }
-ship = { name = "Esmeralda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "O'Higgins" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL version_name = "O'Higgins Class" } } }
-ship = { name = "Presidente Errauriz" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Blanco Encalada" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Blanco Encalada Class" } } }
-ship = { name = "Ministro Zenteno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Ministro Zenteno Class" } } }
-ship = { name = "Chacabuco" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHL } } }
-ship = { name = "Almirante Lynch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Almirante Condell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Capitan Orella" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Capitan Munez Gamero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Teniente Serrano" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Guardia-Marina Riquelme" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Capitan Merino Jarpa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
-ship = { name = "Capitan O'Brien" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
-ship = { name = "Capitan Thompson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL version_name = "Capitan Thompson Class" } } }
-
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/CHL_1914.txt
+++ b/mod/thegreatwar/history/units/CHL_1914.txt
@@ -33,6 +33,36 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Chilean Fleet Fleet"
+	naval_base = 8222 # Santiago
+	task_force = {
+		name = "Chilean Fleet"
+		location = 8222 # Santiago
+		ship = { name = "Huascar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Almirante Cochrane" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Almirante Cochrane Class" } } }
+		ship = { name = "Capitan Prat" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Capitan Prat Class" } } }
+		ship = { name = "Esmeralda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "O'Higgins" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL version_name = "O'Higgins Class" } } }
+		ship = { name = "Presidente Errauriz" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Blanco Encalada" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Blanco Encalada Class" } } }
+		ship = { name = "Ministro Zenteno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Ministro Zenteno Class" } } }
+		ship = { name = "Chacabuco" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHL } } }
+		ship = { name = "Almirante Lynch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Almirante Condell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
+		ship = { name = "Capitan Orella" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Capitan Munez Gamero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Teniente Serrano" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Guardia-Marina Riquelme" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
+		ship = { name = "Capitan Merino Jarpa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
+		ship = { name = "Capitan O'Brien" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
+		ship = { name = "Capitan Thompson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL version_name = "Capitan Thompson Class" } } }
+		ship = { name = "Almirante Lynch" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHL } } }
+		ship = { name = "Almirante Condell" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHL } } }
+	}
+}
+
 	division= { 
 			name = "1. División de Infantería"
 			location=650 # Santiago
@@ -63,33 +93,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Chilean Fleet"
-		location=8222 # Santiago
-		base=8222 # Santiago
-ship = { name = "Huascar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Almirante Cochrane" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Almirante Cochrane Class" } } }
-ship = { name = "Capitan Prat" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = CHL version_name = "Capitan Prat Class" } } }
-ship = { name = "Esmeralda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "O'Higgins" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = CHL version_name = "O'Higgins Class" } } }
-ship = { name = "Presidente Errauriz" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Blanco Encalada" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Blanco Encalada Class" } } }
-ship = { name = "Ministro Zenteno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = CHL version_name = "Ministro Zenteno Class" } } }
-ship = { name = "Chacabuco" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = CHL } } }
-ship = { name = "Almirante Lynch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Almirante Condell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL } } }
-ship = { name = "Capitan Orella" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Capitan Munez Gamero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Teniente Serrano" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Guardia-Marina Riquelme" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = CHL version_name = "Capitan Orella Class" } } }
-ship = { name = "Capitan Merino Jarpa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
-ship = { name = "Capitan O'Brien" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL } } }
-ship = { name = "Capitan Thompson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = CHL version_name = "Capitan Thompson Class" } } }
-ship = { name = "Almirante Lynch" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHL } } }
-ship = { name = "Almirante Condell" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = CHL } } }
-
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/COL_1910.txt
+++ b/mod/thegreatwar/history/units/COL_1910.txt
@@ -33,6 +33,17 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada de Colombia Fleet"
+	naval_base = 12790 # Barranquilla
+	task_force = {
+		name = "Armada de Colombia"
+		location = 12790 # Barranquilla
+		ship = { name = "Cartagena" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = COL } } }
+	}
+}
+
 	division= { 
 			name = "La División"
 			location = 10747 # Bogotá
@@ -47,13 +58,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0
 			}
-	 navy = {
-		name = "Armada de Colombia"
-		location = 12790 # Barranquilla
-		base =  12790 # Barranquilla
-ship = { name = "Cartagena" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = COL } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/COL_1914.txt
+++ b/mod/thegreatwar/history/units/COL_1914.txt
@@ -33,6 +33,17 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada de Colombia Fleet"
+	naval_base = 12790 # Barranquilla
+	task_force = {
+		name = "Armada de Colombia"
+		location = 12790 # Barranquilla
+		ship = { name = "Cartagena" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = COL } } }
+	}
+}
+
 	division= { 
 			name = "La División"
 			location = 10747 # Bogotá
@@ -47,13 +58,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0
 			}
-	 navy = {
-		name = "Armada de Colombia"
-		location = 12790 # Barranquilla
-		base =  12790 # Barranquilla
-ship = { name = "Cartagena" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = COL } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/DEN_1910.txt
+++ b/mod/thegreatwar/history/units/DEN_1910.txt
@@ -33,6 +33,32 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Kongelige Danske Marine Fleet"
+	naval_base = 6287 # Copenhagen
+	task_force = {
+		name = "Kongelige Danske Marine"
+		location = 6287 # Copenhagen
+		ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Olfert Fischer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Peder Skram" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Skjold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Skjold Class" } } }
+		ship = { name = "KDM Iver Hvitfeldt" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Iver Hvitfeldt Class" } } }
+		ship = { name = "KDM Odin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Odin Class" } } }
+		ship = { name = "KDM Gorm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Gorm Class" } } }
+		ship = { name = "KDM Heimdal" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Geiser" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Hekla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Valkyrien" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN version_name = "Valkyrien Class" } } }
+	}
+	task_force = {
+		name = "Ubaatsflottiljen"
+		location = 6287 # Copenhagen
+		ship = { name = "KDM Dykkeren" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = DEN } } }
+	}
+}
+
 	division= { 
 			name = "Den Kongelige Livgarde Division"
 			location=6287 # Copenhagen
@@ -65,31 +91,8 @@ units = {
 			}
 
 			
-	 navy = {
-		name = "Kongelige Danske Marine"
-		location=6287 # Copenhagen
-		base=6287 # Copenhagen
-ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Olfert Fischer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Peder Skram" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Skjold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Skjold Class" } } }
-ship = { name = "KDM Iver Hvitfeldt" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Iver Hvitfeldt Class" } } }
-ship = { name = "KDM Odin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Odin Class" } } }
-ship = { name = "KDM Gorm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Gorm Class" } } }
-ship = { name = "KDM Heimdal" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Geiser" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Hekla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Valkyrien" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN version_name = "Valkyrien Class" } } }
-
-		
-		}
-			 navy = {
-		name = "Ubaatsflottiljen"
-		location=6287 # Copenhagen
-		base=6287 # Copenhagen
-
-ship = { name = "KDM Dykkeren" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = DEN } } }
-		}
+	 
+			 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/DEN_1914.txt
+++ b/mod/thegreatwar/history/units/DEN_1914.txt
@@ -33,6 +33,40 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Kongelige Danske Marine Fleet"
+	naval_base = 6287 # Copenhagen#ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+	task_force = {
+		name = "Kongelige Danske Marine"
+		location = 6287 # Copenhagen#ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Olfert Fischer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Peder Skram" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Skjold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Skjold Class" } } }
+		ship = { name = "KDM Iver Hvitfeldt" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Iver Hvitfeldt Class" } } }
+		ship = { name = "KDM Heimdal" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Geiser" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Valkyrien" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN version_name = "Valkyrien Class" } } }
+	}
+}
+
+fleet = {
+	name = "Ubaatsflottiljen Fleet"
+	naval_base = 6287 # Copenhagen
+	task_force = {
+		name = "Ubaatsflottiljen"
+		location = 6287 # Copenhagen
+		ship = { name = "KDM Dykkeren" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Havmanden" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Havfruen" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Thetis" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Triton" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
+		ship = { name = "KDM Najaden" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
+	}
+}
+
 	division= { 
 			name = "Den Kongelige Livgarde Division"
 			location=6287 # Copenhagen
@@ -82,33 +116,8 @@ units = {
 
 
 			
-	 navy = {
-		name = "Kongelige Danske Marine"
-		location=6287 # Copenhagen
-		base=6287 # Copenhagen#ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Herluf Trolle" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Olfert Fischer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Peder Skram" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Skjold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Skjold Class" } } }
-ship = { name = "KDM Iver Hvitfeldt" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = DEN version_name = "Iver Hvitfeldt Class" } } }
-ship = { name = "KDM Heimdal" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Geiser" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Valkyrien" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = DEN version_name = "Valkyrien Class" } } }
-
-
-		}
-	 navy = {
-		name = "Ubaatsflottiljen"
-		location=6287 # Copenhagen
-		base=6287 # Copenhagen
-ship = { name = "KDM Dykkeren" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Havmanden" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Havfruen" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Thetis" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Triton" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
-ship = { name = "KDM Najaden" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = DEN } } }
-
-		}
+	 
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/ECU_1910.txt
+++ b/mod/thegreatwar/history/units/ECU_1910.txt
@@ -33,18 +33,24 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Ecuadorian Fleet Fleet"
+	naval_base = 8252 # Manta
+	task_force = {
+		name = "Ecuadorian Fleet"
+		location = 8252 # Manta
+		ship = { name = "1st Flotilla" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ECU } } }
+	}
+}
+
 	division= { 
 			name = "1a Brigada de Infantería"
 			location=12798 # Quito
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-	 #navy = {
-	#	name = "Ecuadorian Fleet"
-	#	location = 8252 # Manta
-	#	base =  8252 # Manta
-	#	 #ship = { name = "1st Flotilla" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ECU } } } #type = destroyer  historical_model = 0 
-	#	}
+	 #
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/ECU_1914.txt
+++ b/mod/thegreatwar/history/units/ECU_1914.txt
@@ -33,18 +33,24 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Ecuadorian Fleet Fleet"
+	naval_base = 8252 # Manta
+	task_force = {
+		name = "Ecuadorian Fleet"
+		location = 8252 # Manta
+		ship = { name = "1st Flotilla" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ECU } } }
+	}
+}
+
 	division= { 
 			name = "1a Brigada de Infantería"
 			location=12798 # Quito
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-	# navy = {
-	#	name = "Ecuadorian Fleet"
-	#	location = 8252 # Manta
-	#	base =  8252 # Manta
-	#	 #ship = { name = "1st Flotilla" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ECU } } } #type = destroyer  historical_model = 0 
-	#	}
+	# 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/ENG_1910.txt
+++ b/mod/thegreatwar/history/units/ENG_1910.txt
@@ -94,6 +94,636 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "China Squadron Fleet"
+	naval_base = 10062 # Hong Kong
+	task_force = {
+		name = "China Squadron"
+		location = 10062 # Hong Kong
+		ship = { name = "HMS Kent" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Monmouth" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Hampshire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Minotaur" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
+		ship = { name = "HMS Derwent" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Eden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Waveney" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Boyne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Doon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Kale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Erne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ettrick" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Exe" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Cherwell" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Harwich Force Fleet"
+	naval_base = 9458 # Portsmouth
+	task_force = {
+		name = "Reserve Fleet"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS Majestic" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Caesar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Orion" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Belleisle Class" } } }
+		ship = { name = "HMS Camperdown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Admiral Class" } } }
+		ship = { name = "HMS Howe" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Admiral Class" } } }
+		ship = { name = "HMS Trafalgar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Trafalgar Class" } } }
+		ship = { name = "HMS Nile" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Trafalgar Class" } } }
+		ship = { name = "HMS Empress of India" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Ramilles" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Repulse" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Resolution" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Revenge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Royal Oak" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Royal Sovereign" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Hood" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Hood Class" } } }
+		ship = { name = "HMS Renown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Renown Class" } } }
+		ship = { name = "HMS Hannibal" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Illustrious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Magnificent" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Mars" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Prince George" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Victorious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Bulwark" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS London" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Albemarle" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "Channel Fleet"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS Venerable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Exmouth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Russell" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Africa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Britannia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Commonwealth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Dominion" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Agamemnon" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
+		ship = { name = "HMS Lord Nelson" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
+		ship = { name = "HMS Drake" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Good Hope" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS King Alfred" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Leviathan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Argyll" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Devonshire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Diamond" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
+		ship = { name = "HMS Topaze" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
+		ship = { name = "HMS Proserpine" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Otter" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Leopard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Vixen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Brazen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Electra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Recruit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Vulture" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Kestrel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+	}
+	task_force = {
+		name = "Harwich Force"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS St. George" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Amethyst" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
+		ship = { name = "HMS Dido" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Hermes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMS Cheerful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Mermaid" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Greyhound" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Racehorse" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Roebuck" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Gipsy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Fairy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Osprey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Leven" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Falcon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Ostrich" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Thorn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Vigilant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Albatross" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Velox" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Desperate" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Fame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Foam" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Mallard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Angler" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Coquette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Cynthia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Cygnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Stag" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+	}
+	task_force = {
+		name = "1st Submarine Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS Holland 1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Holland 2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Holland 3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Holland 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Holland 5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "2nd Submarine Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS A1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+	}
+	task_force = {
+		name = "3rd Submarine Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS A7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A12" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A13" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+	}
+	task_force = {
+		name = "4th Submarine Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS B1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+	}
+	task_force = {
+		name = "5th Submarine Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS B7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+	}
+}
+
+fleet = {
+	name = "Forth Patrol Fleet"
+	naval_base = 351 # Newcastle
+	task_force = {
+		name = "Forth Patrol"
+		location = 351 # Newcastle
+		ship = { name = "HMS Pathfinder" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
+		ship = { name = "HMS Patrol" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
+		ship = { name = "HMS Sentinel" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
+		ship = { name = "HMS Thrasher" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Virago" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Earnest" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Griffon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Locust" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Panther" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Seal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Wolf" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Express" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Orwell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Lively" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Sprightly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Success" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Spiteful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Peterel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Myrmidon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Syren" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Kangaroo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Arab" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Albacore" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Bonetta" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Star" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Whiting" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Bat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Crane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Flying Fish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Fawn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Flirt" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Bullfinch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Dove" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Violet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Sylvia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Avon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Bittern" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+	}
+}
+
+fleet = {
+	name = "Mediterranean Flotilla Fleet"
+	naval_base = 12003 # Malta
+	task_force = {
+		name = "Mediterranean Flotilla"
+		location = 12003 # Malta
+		ship = { name = "HMS C35" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C36" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C37" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C38" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D1" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Mediterranean Fleet Fleet"
+	naval_base = 4135 # Gibraltar
+	task_force = {
+		name = "Mediterranean Fleet"
+		location = 4135 # Gibraltar
+		ship = { name = "HMS Queen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Prince of Wales" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Cornwallis" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Duncan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Swiftsure" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
+		ship = { name = "HMS Triumph" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
+		ship = { name = "HMS Black Prince" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
+		ship = { name = "HMS Duke of Edinburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
+		ship = { name = "HMS Defence" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
+		ship = { name = "HMS Welland" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Garry" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Foyle" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Itchen" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Arun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Liffey" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Moy" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ouse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Stour" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Test" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Kennet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Jed" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Chelmer" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Colne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ness" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Nith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "9th Cruiser Squadron"
+		location = 4135 # Gibraltar
+		ship = { name = "HMS Amphitrite" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Argonaut" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Europa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Sutlej" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Vindictive" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Highflyer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMS Challenger" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMS Dee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Rother" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Swale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Wear" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ribble" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Teviot" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Usk" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Dover Patrol Fleet"
+	naval_base = 3501 # Dover
+	task_force = {
+		name = "Dover Patrol"
+		location = 3501 # Dover
+		ship = { name = "HMS Aboukir" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Bacchante" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Cressy" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Euryalus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Hogue" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Bedford" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Cumberland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Adventure" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Attentive" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Forward" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
+		ship = { name = "HMS Wizard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Teazer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Fervent" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Zephyr" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Handy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Hunter" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Hart" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Opossum" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Sunfish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ranger" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Rocket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Surly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Shark" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Sturgeon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Starfish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Spitfire" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Zebra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Quail" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+	}
+}
+
+fleet = {
+	name = "N. America & W. Indies Squadron Fleet"
+	naval_base = 12304 # Kingston
+	task_force = {
+		name = "N. America & W. Indies Squadron"
+		location = 12304 # Kingston
+		ship = { name = "HMS Berwick" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Essex" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Suffolk" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+	}
+}
+
+fleet = {
+	name = "5th Cruiser Squadron Fleet"
+	naval_base = 2038 # Freetown
+	task_force = {
+		name = "5th Cruiser Squadron"
+		location = 2038 # Freetown
+		ship = { name = "HMS Cornwall" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Donegal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Lancaster" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+	}
+}
+
+fleet = {
+	name = "Nore Force Fleet"
+	naval_base = 271 # Lowestoft
+	task_force = {
+		name = "Nore Force"
+		location = 271 # Lowestoft
+		ship = { name = "HMS Inflexible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Jupiter" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Albion" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Canopus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+	}
+}
+
+fleet = {
+	name = "East Coast Force Fleet"
+	naval_base = 11297 # Hull
+	task_force = {
+		name = "East Coast Force"
+		location = 11297 # Hull
+		ship = { name = "HMS Skirmisher" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
+		ship = { name = "HMS Havock" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Daring" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ferret" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Lynx" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ardent" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Boxer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Bruizer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Charger" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Hasty" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Dasher" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Hardy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Haughty" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Janus" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Lightning" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Porcupine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Salmon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Snapper" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Banshee" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Dragon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Contest" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Conflict" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "6th Submarine Flotilla"
+		location = 11297 # Hull
+		ship = { name = "HMS C1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C6" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "8th Submarine Flotilla"
+		location = 11297 # Hull
+		ship = { name = "HMS C15" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C16" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C17" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C18" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C19" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C20" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "9th Submarine Flotilla"
+		location = 11297 # Hull
+		ship = { name = "HMS C21" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C22" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C23" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C24" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C25" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C26" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "11th Cruiser Squadron Fleet"
+	naval_base = 11293 # Cork
+	task_force = {
+		name = "11th Cruiser Squadron"
+		location = 11293 # Cork
+		ship = { name = "HMS Doris" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Isis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Juno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Venus" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+	}
+}
+
+fleet = {
+	name = "Cape Squadron Fleet"
+	naval_base = 12589 # Cape Town
+	task_force = {
+		name = "Cape Squadron"
+		location = 12589 # Cape Town
+		ship = { name = "HMS Astraea" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Bonadventure" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Pegasus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Hyacinth" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+	}
+}
+
+fleet = {
+	name = "East Indies Squadron Fleet"
+	naval_base = 10201 # Colombo
+	task_force = {
+		name = "East Indies Squadron"
+		location = 10201 # Colombo
+		ship = { name = "HMS Fox" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+	}
+}
+
+fleet = {
+	name = "Home Fleet"
+	naval_base = 540 # Plymouth
+	task_force = {
+		name = "Home Fleet Main Task Force"
+		location = 540 # Plymouth
+		ship = { name = "HMS Dreadnought" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Bellerophon" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
+		ship = { name = "HMS Superb" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
+		ship = { name = "HMS Temeraire" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
+		ship = { name = "HMS Collingwood" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
+		ship = { name = "HMS St. Vincent" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
+		ship = { name = "HMS Vanguard" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
+		ship = { name = "HMS Ocean" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Vengeance" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Formidable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
+		ship = { name = "HMS Irresistible" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
+		ship = { name = "HMS Implacable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
+		ship = { name = "HMS Hibernia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Hindustan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS King Edward VII" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Zealandia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Indomitable" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Invincible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ariadne" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Diadem" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Andromeda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Spartiate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Powerful" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
+		ship = { name = "HMS Terrible" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
+		ship = { name = "HMS Warrior" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Antrim" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Carnarvon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Roxburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Bellona" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Boadicea Class" } } }
+		ship = { name = "HMS Sapphire" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
+		ship = { name = "HMS Sappho" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Arrogant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Furious" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Flora" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Cambrian" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Forte" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Sirius" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Iphigenia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Latona" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Hermione" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Brilliant" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Medea" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Medusa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Barham" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Barham Class" } } }
+		ship = { name = "HMS Wallaroo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Pearl Class" } } }
+		ship = { name = "HMS Aeolus" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Andromache" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Apollo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Indefatigable" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Intrepid" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Naiad" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Pique" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Retribution" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Scylla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Spartan" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Terpsichore" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Thetis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Tribune" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
+		ship = { name = "HMS Boadicea" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Boadicea Class" } } }
+		ship = { name = "HMS Afridi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Cossack" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ghurka" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Tartar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Amazon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Saracen" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Crusader" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Maori" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Nubian" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Viking" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Zulu" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Beagle" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Bulldog" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Foxhound" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Harpy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Basilisk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Grasshopper" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Mosquito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Scorpion" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Nautilus" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Pincher" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Renard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Wolverine" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Racoon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Rattlesnake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Savage" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Scourge" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Parramatta" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Yarra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Swift" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+	}
+	task_force = {
+		name = "Sheerness Force"
+		location = 540 # Plymouth
+		ship = { name = "HMS Glory" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Goliath" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+	}
+	task_force = {
+		name = "12th Cruiser Squadron"
+		location = 540 # Plymouth
+		ship = { name = "HMS Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Eclipse" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Talbot" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Charybdis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Pandora" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Pelorus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Pactolus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Pomone" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Prometheus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Perseus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+	}
+	task_force = {
+		name = "10th Submarine Flotilla"
+		location = 540 # Plymouth
+		ship = { name = "HMS C27" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C28" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C29" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C30" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C31" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C32" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "2nd Cruiser Squadron Fleet"
+	naval_base = 6395 # Aberdeen
+	task_force = {
+		name = "2nd Cruiser Squadron"
+		location = 6395 # Aberdeen
+		ship = { name = "HMS Achilles" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Cochrane" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Natal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Shannon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
+	}
+}
+
+fleet = {
+	name = "Northern Patrol Fleet"
+	naval_base = 3379 # Belfast
+	task_force = {
+		name = "Northern Patrol"
+		location = 3379 # Belfast
+		ship = { name = "HMS Blake" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Blenham" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Crescent" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Edgar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Endymion" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Gibraltar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Grafton" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Hawke" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Royal Arthur" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Theseus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Foresight" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
+	}
+}
+
+fleet = {
+	name = "7th Submarine Flotilla Fleet"
+	naval_base = 6300 # Rosyth
+	task_force = {
+		name = "7th Submarine Flotilla"
+		location = 6300 # Rosyth
+		ship = { name = "HMS C7" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C13" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+}
+
 	division= { 
 			name = "1st Infantry Division"
 			location = 11471 # Oxford
@@ -408,597 +1038,37 @@ division= {
 	start_equipment_factor = 0.3 
 	start_manpower_factor = 0.3
 	}
- navy = {
-name = "Home Fleet"
-location = 540 # Plymouth
-base =  540 # Plymouth
-ship = { name = "HMS Dreadnought" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Bellerophon" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
-ship = { name = "HMS Superb" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
-ship = { name = "HMS Temeraire" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
-ship = { name = "HMS Collingwood" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
-ship = { name = "HMS St. Vincent" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
-ship = { name = "HMS Vanguard" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
-ship = { name = "HMS Ocean" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Vengeance" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Formidable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
-ship = { name = "HMS Irresistible" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
-ship = { name = "HMS Implacable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
-ship = { name = "HMS Hibernia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Hindustan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS King Edward VII" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Zealandia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Indomitable" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Invincible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ariadne" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Diadem" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Andromeda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Spartiate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Powerful" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
-ship = { name = "HMS Terrible" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
-ship = { name = "HMS Warrior" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Antrim" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-ship = { name = "HMS Carnarvon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-ship = { name = "HMS Roxburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-ship = { name = "HMS Bellona" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Boadicea Class" } } }
-ship = { name = "HMS Sapphire" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
-ship = { name = "HMS Sappho" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Arrogant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Furious" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Flora" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Cambrian" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Forte" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Sirius" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Iphigenia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Latona" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Hermione" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Brilliant" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Medea" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Medusa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Barham" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Barham Class" } } }
-ship = { name = "HMS Wallaroo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Pearl Class" } } }
-ship = { name = "HMS Aeolus" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Andromache" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Apollo" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Indefatigable" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Intrepid" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Naiad" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Pique" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Retribution" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Scylla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Spartan" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Terpsichore" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Thetis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Tribune" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Apollo Class" } } }
-ship = { name = "HMS Boadicea" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Boadicea Class" } } }
-ship = { name = "HMS Afridi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Cossack" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ghurka" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Tartar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Amazon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Saracen" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Crusader" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Maori" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Nubian" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Viking" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Zulu" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Beagle" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Bulldog" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Foxhound" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Harpy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Basilisk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Grasshopper" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Mosquito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Scorpion" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Nautilus" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Pincher" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Renard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Wolverine" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Racoon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Rattlesnake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Savage" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Scourge" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Parramatta" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Yarra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Swift" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
 
-}
- navy = {
-name = "Nore Force"
-location = 271 # Lowestoft
-base =  271 # Lowestoft
-ship = { name = "HMS Inflexible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Jupiter" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Albion" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Canopus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-
-}
- navy = {
-name = "Reserve Fleet"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS Majestic" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Caesar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Orion" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Belleisle Class" } } }
-ship = { name = "HMS Camperdown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Admiral Class" } } }
-ship = { name = "HMS Howe" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Admiral Class" } } }
-ship = { name = "HMS Trafalgar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Trafalgar Class" } } }
-ship = { name = "HMS Nile" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Trafalgar Class" } } }
-ship = { name = "HMS Empress of India" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Ramilles" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Repulse" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Resolution" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Revenge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Royal Oak" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Royal Sovereign" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Hood" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Hood Class" } } }
-ship = { name = "HMS Renown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Renown Class" } } }
-ship = { name = "HMS Hannibal" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Illustrious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Magnificent" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Mars" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Prince George" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Victorious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Bulwark" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS London" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Albemarle" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-
-}
- navy = {
-name = "Sheerness Force"
-location = 540 # Plymouth
-base =  540 # Plymouth
-ship = { name = "HMS Glory" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Goliath" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-
-}
- navy = {
-name = "2nd Cruiser Squadron"
-location = 6395 # Aberdeen
-base =  6395 # Aberdeen
-ship = { name = "HMS Achilles" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Cochrane" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Natal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Shannon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
-
-}
- navy = {
-name = "Channel Fleet"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS Venerable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Exmouth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Russell" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Africa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Britannia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Commonwealth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Dominion" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Agamemnon" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
-ship = { name = "HMS Lord Nelson" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
-ship = { name = "HMS Drake" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Good Hope" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS King Alfred" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Leviathan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Argyll" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-ship = { name = "HMS Devonshire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-ship = { name = "HMS Diamond" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
-ship = { name = "HMS Topaze" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
-ship = { name = "HMS Proserpine" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Otter" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Leopard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Vixen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Brazen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Electra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Recruit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Vulture" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Kestrel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-
-}
- navy = {
-name = "Harwich Force"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS St. George" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Amethyst" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
-ship = { name = "HMS Dido" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Hermes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-
-ship = { name = "HMS Cheerful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Mermaid" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Greyhound" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Racehorse" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Roebuck" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Gipsy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Fairy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Osprey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Leven" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Falcon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Ostrich" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Thorn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Vigilant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Albatross" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Velox" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Desperate" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Fame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Foam" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Mallard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Angler" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Coquette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Cynthia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Cygnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Stag" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-
-}
- navy = {
-name = "East Coast Force"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS Skirmisher" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
-ship = { name = "HMS Havock" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Daring" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ferret" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Lynx" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ardent" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Boxer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Bruizer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Charger" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Hasty" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Dasher" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Hardy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Haughty" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Janus" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Lightning" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Porcupine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Salmon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Snapper" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Banshee" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Dragon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Contest" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Conflict" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-
-}
- navy = {
-name = "Dover Patrol"
-location = 3501 # Dover
-base =  3501 # Dover
-ship = { name = "HMS Aboukir" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Bacchante" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Cressy" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Euryalus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Hogue" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Bedford" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Cumberland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Adventure" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Attentive" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Forward" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
-ship = { name = "HMS Wizard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Teazer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Fervent" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Zephyr" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Handy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Hunter" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Hart" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Opossum" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Sunfish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ranger" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Rocket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Surly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Shark" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Sturgeon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Starfish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Spitfire" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Zebra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Quail" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-
-}
- navy = {
-name = "Forth Patrol"
-location=351 # Newcastle
-base=351 # Newcastle
-ship = { name = "HMS Pathfinder" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
-ship = { name = "HMS Patrol" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
-ship = { name = "HMS Sentinel" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
-ship = { name = "HMS Thrasher" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Virago" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Earnest" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Griffon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Locust" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Panther" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Seal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Wolf" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Express" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Orwell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Lively" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Sprightly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Success" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Spiteful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Peterel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Myrmidon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Syren" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Kangaroo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Arab" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Albacore" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Bonetta" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Star" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Whiting" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Bat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Crane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Flying Fish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Fawn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Flirt" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Bullfinch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Dove" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Violet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Sylvia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Avon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Bittern" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-
-}
- navy = {
-name = "Northern Patrol"
-location=3379 # Belfast
-base=3379 # Belfast
-ship = { name = "HMS Blake" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Blenham" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Crescent" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Edgar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Endymion" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Gibraltar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Grafton" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Hawke" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Royal Arthur" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Theseus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Foresight" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
-
-}
- navy = {
-name = "11th Cruiser Squadron"
-location=11293 # Cork
-base=11293 # Cork
-ship = { name = "HMS Doris" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Isis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Juno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Venus" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-}
- navy = {
-name = "12th Cruiser Squadron"
-location = 540 # Plymouth
-base =  540 # Plymouth
-ship = { name = "HMS Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Eclipse" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Talbot" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Charybdis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Pandora" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Pelorus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Pactolus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Pomone" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Prometheus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Perseus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-}
- navy = {
-name = "1st Submarine Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS Holland 1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Holland 2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Holland 3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Holland 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Holland 5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
-
-}
- navy = {
-name = "2nd Submarine Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS A1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-
-}
- navy = {
-name = "3rd Submarine Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS A7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A12" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A13" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-}
- navy = {
-name = "4th Submarine Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS B1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-}
- navy = {
-name = "5th Submarine Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS B7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-}
- navy = {
-name = "6th Submarine Flotilla"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS C1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C6" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "7th Submarine Flotilla"
-location = 6300 # Rosyth
-base =  6300 # Rosyth
-ship = { name = "HMS C7" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C13" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "8th Submarine Flotilla"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS C15" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C16" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C17" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C18" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C19" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C20" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "9th Submarine Flotilla"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS C21" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C22" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C23" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C24" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C25" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C26" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "10th Submarine Flotilla"
-location = 540 # Plymouth
-base =  540 # Plymouth
-ship = { name = "HMS C27" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C28" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C29" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C30" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C31" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C32" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "Mediterranean Flotilla"
-location = 12003 # Malta
-base =  12003 # Malta
-ship = { name = "HMS C35" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C36" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C37" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C38" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D1" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-}
-navy = {
-name = "Mediterranean Fleet"
-location = 4135 # Gibraltar
-base = 4135 # Gibraltar
-ship = { name = "HMS Queen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Prince of Wales" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Cornwallis" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Duncan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Swiftsure" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
-ship = { name = "HMS Triumph" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
-ship = { name = "HMS Black Prince" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
-ship = { name = "HMS Duke of Edinburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
-ship = { name = "HMS Defence" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
-ship = { name = "HMS Welland" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Garry" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Foyle" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Itchen" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Arun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Liffey" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Moy" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ouse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Stour" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Test" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Kennet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Jed" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Chelmer" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Colne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ness" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Nith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-
-}
- navy = {
-name = "9th Cruiser Squadron"
-location = 4135 # Gibraltar
-base = 4135 # Gibraltar
-ship = { name = "HMS Amphitrite" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Argonaut" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Europa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Sutlej" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Vindictive" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Highflyer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-ship = { name = "HMS Challenger" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-ship = { name = "HMS Dee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Rother" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Swale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Wear" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ribble" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Teviot" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Usk" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "China Squadron"
-location = 10062 # Hong Kong
-base = 10062 # Hong Kong
-ship = { name = "HMS Kent" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Monmouth" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Hampshire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-ship = { name = "HMS Minotaur" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
-ship = { name = "HMS Derwent" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Eden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Waveney" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Boyne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Doon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Kale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Erne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ettrick" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Exe" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Cherwell" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-
-}
- navy = {
-name = "East Indies Squadron"
-location = 10201 # Colombo
-base = 10201 # Colombo
-ship = { name = "HMS Fox" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-}
- navy = {
-name = "N. America & W. Indies Squadron"
-location = 12304 # Kingston
-base = 12304 # Kingston
-ship = { name = "HMS Berwick" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Essex" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Suffolk" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-}
- navy = {
-name = "5th Cruiser Squadron"
-location = 2038 # Freetown
-base = 2038 # Freetown
-ship = { name = "HMS Cornwall" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Donegal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Lancaster" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-}
- navy = {
-name = "Cape Squadron"
-location = 12589 # Cape Town
-base = 12589 # Cape Town
-ship = { name = "HMS Astraea" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Bonadventure" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Pegasus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Hyacinth" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-}
+ 
+ 
+ 
+ 
+ 
+ 
 
 
 }

--- a/mod/thegreatwar/history/units/ENG_1914.txt
+++ b/mod/thegreatwar/history/units/ENG_1914.txt
@@ -95,6 +95,636 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Grand Fleet"
+	naval_base = 11064 # Scapa Flow
+	task_force = {
+		name = "Grand Fleet Main Task Force"
+		location = 11064 # Scapa Flow
+		ship = { name = "HMS Africa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Britannia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Commonwealth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Dominion" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Hibernia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Hindustan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS King Edward VII" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Zealandia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
+		ship = { name = "HMS Dreadnought" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Bellerophon" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
+		ship = { name = "HMS Superb" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
+		ship = { name = "HMS Temeraire" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
+		ship = { name = "HMS Collingwood" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
+		ship = { name = "HMS St. Vincent" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
+		ship = { name = "HMS Vanguard" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
+		ship = { name = "HMS Neptune" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Colossus" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Colossus Class" } } }
+		ship = { name = "HMS Hercules" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Colossus Class" } } }
+		ship = { name = "HMS Conqueror" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
+		ship = { name = "HMS Monarch" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
+		ship = { name = "HMS Orion" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
+		ship = { name = "HMS Thunderer" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
+		ship = { name = "HMS King George V" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
+		ship = { name = "HMS Centurion" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
+		ship = { name = "HMS Audacious" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
+		ship = { name = "HMS Ajax" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
+		ship = { name = "HMS Barham" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Channel Fleet"
+	naval_base = 9458 # Portsmouth
+	task_force = {
+		name = "Channel Fleet Main Task Force"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS Majestic" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Albion" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Canopus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Glory" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Goliath" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Ocean" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Vengeance" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
+		ship = { name = "HMS Formidable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
+		ship = { name = "HMS Irresistible" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
+		ship = { name = "HMS Implacable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
+		ship = { name = "HMS Bulwark" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS London" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Venerable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Queen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Prince of Wales" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
+		ship = { name = "HMS Albemarle" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Cornwallis" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Duncan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Exmouth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Russell" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Lord Nelson" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
+		ship = { name = "HMS Agamemnon" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
+		ship = { name = "HMS Perseus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Pactolus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Pomone" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Prometheus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Proserpine" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Diamond" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
+		ship = { name = "HMS Topaze" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
+		ship = { name = "HMS Boxer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Bruizer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Janus" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Lightning" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Porcupine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Conflict" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Wizard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Fervent" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Zephyr" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Handy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Opossum" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Sunfish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ranger" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Surly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Zebra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Quail" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Thrasher" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Virago" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Earnest" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Griffon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Locust" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Panther" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Seal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Wolf" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Express" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Orwell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Lively" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Sprightly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Success" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Spiteful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Peterel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Myrmidon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+	}
+	task_force = {
+		name = "Harwich Force"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS Resolution" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Revenge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Royal Oak" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
+		ship = { name = "HMS Hood" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Hood Class" } } }
+		ship = { name = "HMS Renown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Renown Class" } } }
+		ship = { name = "HMS Caesar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Illustrious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Jupiter" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Prince George" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Dido" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Hermes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMS Amethyst" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
+		ship = { name = "HMS Amphion" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Active Class" } } }
+		ship = { name = "HMS Derwent" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Eden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Waveney" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Boyne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Doon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Kale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Erne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ettrick" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Exe" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Cherwell" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Dee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Rother" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Swale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Wear" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ribble" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Teviot" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Usk" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "1st Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS Holland 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS A2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A12" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+		ship = { name = "HMS A13" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
+	}
+	task_force = {
+		name = "3rd Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS B1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+	}
+	task_force = {
+		name = "5th Flotilla"
+		location = 9458 # Portsmouth
+		ship = { name = "HMS B7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS B11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
+	}
+}
+
+fleet = {
+	name = "East Coast Force Fleet"
+	naval_base = 11297 # Hull
+	task_force = {
+		name = "East Coast Force"
+		location = 11297 # Hull
+		ship = { name = "HMS Hannibal" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Magnificent" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Mars" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Victorious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
+		ship = { name = "HMS Skirmisher" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
+		ship = { name = "HMS Osprey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Leven" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Falcon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Ostrich" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Thorn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Vigilant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Albatross" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Velox" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Desperate" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Fame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Foam" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Mallard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Angler" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Coquette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Cynthia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Cygnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+		ship = { name = "HMS Stag" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
+	}
+	task_force = {
+		name = "6th Flotilla"
+		location = 11297 # Hull
+		ship = { name = "HMS C1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C6" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C7" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "8th Flotilla"
+		location = 11297 # Hull
+		ship = { name = "HMS C17" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C18" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C19" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C20" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C21" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C22" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C23" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C24" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "9th Flotilla"
+		location = 11297 # Hull
+		ship = { name = "HMS C25" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C26" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C27" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C28" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C29" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C30" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C31" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C32" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Forth Patrol Fleet"
+	naval_base = 351 # Newcastle
+	task_force = {
+		name = "Forth Patrol"
+		location = 351 # Newcastle
+		ship = { name = "HMS Pathfinder" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
+		ship = { name = "HMS Patrol" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
+		ship = { name = "HMS Sentinel" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
+		ship = { name = "HMS Syren" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Kangaroo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Arab" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Albacore" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Bonetta" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
+		ship = { name = "HMS Star" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Whiting" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Bat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Crane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Flying Fish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Fawn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Flirt" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Bullfinch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Dove" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Violet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Sylvia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Avon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Bittern" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Otter" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Leopard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Vixen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Brazen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Electra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Recruit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Vulture" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Kestrel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Cheerful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Mermaid" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Racehorse" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Roebuck" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Gipsy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+		ship = { name = "HMS Fairy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
+	}
+}
+
+fleet = {
+	name = "10th Flotilla Fleet"
+	naval_base = 540 # Plymouth
+	task_force = {
+		name = "12th Cruiser Squadron"
+		location = 540 # Plymouth
+		ship = { name = "HMS Charybdis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Eclipse" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Talbot" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Pelorus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+	}
+	task_force = {
+		name = "10th Flotilla"
+		location = 540 # Plymouth
+		ship = { name = "HMS D1" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D2" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D3" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D4" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D5" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D6" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D7" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS D8" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E1" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E2" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E3" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E4" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E5" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E6" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E7" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E8" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E9" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS E10" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Dover Patrol Fleet"
+	naval_base = 3501 # Dover
+	task_force = {
+		name = "Dover Patrol"
+		location = 3501 # Dover
+		ship = { name = "HMS Blake" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Blenham" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Crescent" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Edgar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Endymion" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Gibraltar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Grafton" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Hawke" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Royal Arthur" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS St. George" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Theseus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
+		ship = { name = "HMS Powerful" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
+		ship = { name = "HMS Terrible" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
+		ship = { name = "HMS Amphitrite" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Andromeda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Argonaut" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Ariadne" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Diadem" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Europa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Spartiate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
+		ship = { name = "HMS Aboukir" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Bacchante" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Cressy" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Euryalus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Hogue" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Adventure" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Attentive" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Forward" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
+		ship = { name = "HMS Welland" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Garry" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Foyle" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Itchen" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Arun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Liffey" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Moy" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ouse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Stour" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Test" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Kennet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Jed" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Chelmer" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Colne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ness" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Nith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "9th Cruiser Squadron Fleet"
+	naval_base = 4135 # Gibraltar
+	task_force = {
+		name = "9th Cruiser Squadron"
+		location = 4135 # Gibraltar
+		ship = { name = "HMS Sutlej" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
+		ship = { name = "HMS Vindictive" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Highflyer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMS Challenger" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+	}
+}
+
+fleet = {
+	name = "Battlecruiser Force Fleet"
+	naval_base = 6300 # Rosyth
+	task_force = {
+		name = "Battlecruiser Force"
+		location = 6300 # Rosyth
+		ship = { name = "HMS Invincible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS New Zealand" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Lion" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG version_name = "Lion Class" } } }
+		ship = { name = "HMS Princess Royal" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG version_name = "Lion Class" } } }
+		ship = { name = "HMS Queen Mary" definition = battle_cruiser equipment = { battle_cruiser_1914 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Southampton" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
+	}
+	task_force = {
+		name = "7th Flotilla"
+		location = 6300 # Rosyth
+		ship = { name = "HMS C9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C13" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C15" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C16" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Mediterranean Fleet Fleet"
+	naval_base = 12003 # Malta
+	task_force = {
+		name = "Mediterranean Flotilla"
+		location = 12003 # Malta
+		ship = { name = "HMS C33" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C34" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C35" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C36" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C37" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS C38" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
+	}
+	task_force = {
+		name = "Mediterranean Fleet"
+		location = 12003 # Malta
+		ship = { name = "HMS Indomitable" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Inflexible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Indefatigable" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Black Prince" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
+		ship = { name = "HMS Duke of Edinburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
+		ship = { name = "HMS Warrior" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Defence" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
+		ship = { name = "HMS Gloucester" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Bristol Class" } } }
+		ship = { name = "HMS Weymouth" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Chatham" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
+		ship = { name = "HMS Dublin" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
+		ship = { name = "HMS Beagle" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Bulldog" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Foxhound" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Harpy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Basilisk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Grasshopper" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Mosquito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Scorpion" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Nautilus" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Pincher" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Renard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Wolverine" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Racoon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Rattlesnake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Savage" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Scourge" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
+		ship = { name = "HMS Acorn" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Alarm" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Brisk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Cameleon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Comet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Goldfinch" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Fury" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Hope" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Larne" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Lyra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Martin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Minstrel" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Nemesis" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Nereide" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Nymphe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Redpole" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Rifleman" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Ruby" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Sheldrake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Staunch" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
+		ship = { name = "HMS Acheron" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Archer" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Ariel" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Attack" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Badger" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Beaver" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Defender" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Druid" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Ferret" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Forester" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Goshawk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Hind" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Hornet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Hydra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Jackal" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Lapwing" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Lizard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Phoenix" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Sandfly" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Tigress" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Firedrake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Lurcher" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Oak" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Parramatta" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Yarra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Warrego" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
+		ship = { name = "HMS Acasta" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Achates" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Ambuscade" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Christopher" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Cockatrice" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Contest" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Lynx" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Midge" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Owl" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+		ship = { name = "HMS Shark" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "East Indies Squadron Fleet"
+	naval_base = 10201 # Colombo
+	task_force = {
+		name = "East Indies Squadron"
+		location = 10201 # Colombo
+		ship = { name = "HMS Swiftsure" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
+		ship = { name = "HMS Fox" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Dartmouth" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "N. America & W. Indies Squadron Fleet"
+	naval_base = 12304 # Kingston
+	task_force = {
+		name = "N. America & W. Indies Squadron"
+		location = 12304 # Kingston
+		ship = { name = "HMS Berwick" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Essex" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Suffolk" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Bristol" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Bristol Class" } } }
+	}
+}
+
+fleet = {
+	name = "5th Cruiser Squadron Fleet"
+	naval_base = 2038 # Freetown
+	task_force = {
+		name = "5th Cruiser Squadron"
+		location = 2038 # Freetown
+		ship = { name = "HMS Cornwall" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Cumberland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Donegal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Lancaster" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Monmouth" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Carnarvon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+	}
+}
+
+fleet = {
+	name = "S.E. Coast of America Squadron Fleet"
+	naval_base = 12960 # Falkland Islands
+	task_force = {
+		name = "S.E. Coast of America Squadron"
+		location = 12960 # Falkland Islands
+		ship = { name = "HMS Kent" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
+		ship = { name = "HMS Glasgow" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Bristol Class" } } }
+	}
+}
+
+fleet = {
+	name = "2nd Cruiser Squadron Fleet"
+	naval_base = 6395 # Aberdeen
+	task_force = {
+		name = "2nd Cruiser Squadron"
+		location = 6395 # Aberdeen
+		ship = { name = "HMS Achilles" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Cochrane" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Natal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
+		ship = { name = "HMS Minotaur" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
+		ship = { name = "HMS Shannon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
+	}
+}
+
+fleet = {
+	name = "Northern Patrol Fleet"
+	naval_base = 3379 # Belfast
+	task_force = {
+		name = "Northern Patrol"
+		location = 3379 # Belfast
+		ship = { name = "HMS Foresight" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
+	}
+}
+
+fleet = {
+	name = "11th Cruiser Squadron Fleet"
+	naval_base = 11293 # Cork
+	task_force = {
+		name = "11th Cruiser Squadron"
+		location = 11293 # Cork
+		ship = { name = "HMS Doris" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Isis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Juno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+		ship = { name = "HMS Venus" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
+	}
+}
+
+fleet = {
+	name = "China Squadron Fleet"
+	naval_base = 10062 # Hong Kong
+	task_force = {
+		name = "China Squadron"
+		location = 10062 # Hong Kong
+		ship = { name = "HMS Triumph" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
+		ship = { name = "HMS Hampshire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Roxburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
+		ship = { name = "HMS Minotaur" definition = battle_cruiser equipment = { battle_cruiser_1890b = { amount = 1 owner = ENG } } }
+	}
+}
+
+fleet = {
+	name = "Cape Squadron Fleet"
+	naval_base = 12589 # Cape Town
+	task_force = {
+		name = "Cape Squadron"
+		location = 12589 # Cape Town
+		ship = { name = "HMS Astraea" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
+		ship = { name = "HMS Hyacinth" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
+		ship = { name = "HMS Pegasus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st (Guards) Infantry Division"
 			location = 11471 # Oxford
@@ -459,38 +1089,7 @@ units = {
 			start_manpower_factor = 0.3
 			}
 	
-navy = {
-name = "Grand Fleet"
-location = 11064 # Scapa Flow
-base =  11064 # Scapa Flow
-ship = { name = "HMS Africa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Britannia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Commonwealth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Dominion" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Hibernia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Hindustan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS King Edward VII" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Zealandia" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "King Edward VII Class" } } }
-ship = { name = "HMS Dreadnought" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Bellerophon" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
-ship = { name = "HMS Superb" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
-ship = { name = "HMS Temeraire" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "Bellerophon Class" } } }
-ship = { name = "HMS Collingwood" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
-ship = { name = "HMS St. Vincent" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
-ship = { name = "HMS Vanguard" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG version_name = "St. Vincent Class" } } }
-ship = { name = "HMS Neptune" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Colossus" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Colossus Class" } } }
-ship = { name = "HMS Hercules" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Colossus Class" } } }
-ship = { name = "HMS Conqueror" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
-ship = { name = "HMS Monarch" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
-ship = { name = "HMS Orion" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
-ship = { name = "HMS Thunderer" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "Orion Class" } } }
-ship = { name = "HMS King George V" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
-ship = { name = "HMS Centurion" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
-ship = { name = "HMS Audacious" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
-ship = { name = "HMS Ajax" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ENG version_name = "King George V Class" } } }
-
-#ship = { name = "HMS Barham" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = ENG } } }#KiS#version_name = "Queen Elizabeth Class" } } }
+ } }
 #ship = { name = "HMS Furious" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }#KiS#version_name = "Furious Class" } } }
 
 ship = { name = "HMS Drake" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG } } }
@@ -564,513 +1163,30 @@ ship = { name = "HMS Lysander" definition = destroyer equipment = { destroyer_19
 ship = { name = "HMS Swift" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
 
 }
- navy = {
-name = "Battlecruiser Force"
-location = 6300 # Rosyth
-base =  6300 # Rosyth
-ship = { name = "HMS Invincible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS New Zealand" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Lion" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG version_name = "Lion Class" } } }
-ship = { name = "HMS Princess Royal" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG version_name = "Lion Class" } } }
-ship = { name = "HMS Queen Mary" definition = battle_cruiser equipment = { battle_cruiser_1914 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Southampton" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
 
-}
- navy = {
-name = "2nd Cruiser Squadron"
-location = 6395 # Aberdeen
-base =  6395 # Aberdeen
-ship = { name = "HMS Achilles" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Cochrane" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Natal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Minotaur" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
-ship = { name = "HMS Shannon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
 
-}
- navy = {
-name = "Channel Fleet"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS Majestic" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Albion" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Canopus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Glory" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Goliath" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Ocean" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Vengeance" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Canopus Class" } } }
-ship = { name = "HMS Formidable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
-ship = { name = "HMS Irresistible" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
-ship = { name = "HMS Implacable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Formidable Class" } } }
-ship = { name = "HMS Bulwark" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS London" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Venerable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Queen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Prince of Wales" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "London Class" } } }
-ship = { name = "HMS Albemarle" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Cornwallis" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Duncan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Exmouth" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Russell" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Lord Nelson" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
-ship = { name = "HMS Agamemnon" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Lord Nelson Class" } } }
-ship = { name = "HMS Perseus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Pactolus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Pomone" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Prometheus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Proserpine" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Diamond" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
-ship = { name = "HMS Topaze" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
-ship = { name = "HMS Boxer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Bruizer" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Janus" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Lightning" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Porcupine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Conflict" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Wizard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Fervent" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Zephyr" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Handy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Opossum" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Sunfish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ranger" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Surly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Zebra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Quail" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Thrasher" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Virago" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Earnest" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Griffon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Locust" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Panther" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Seal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Wolf" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Express" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Orwell" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Lively" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Sprightly" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Success" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Spiteful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Peterel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Myrmidon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-
-}
- navy = {
-name = "Harwich Force"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS Resolution" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Revenge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Royal Oak" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Royal Sovereign Class" } } }
-ship = { name = "HMS Hood" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Hood Class" } } }
-ship = { name = "HMS Renown" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Renown Class" } } }
-ship = { name = "HMS Caesar" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Illustrious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Jupiter" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Prince George" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Dido" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Hermes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-ship = { name = "HMS Amethyst" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Gem Class" } } }
-ship = { name = "HMS Amphion" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Active Class" } } }
-ship = { name = "HMS Derwent" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Eden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Waveney" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Boyne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Doon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Kale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Erne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ettrick" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Exe" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Cherwell" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Dee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Rother" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Swale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Wear" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ribble" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Teviot" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Usk" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "East Coast Force"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS Hannibal" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Magnificent" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Mars" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Victorious" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ENG version_name = "Majestic Class" } } }
-ship = { name = "HMS Skirmisher" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
-ship = { name = "HMS Osprey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Leven" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Falcon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Ostrich" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Thorn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Vigilant" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Albatross" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Velox" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Desperate" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Fame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Foam" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Mallard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Angler" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Coquette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Cynthia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Cygnet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-ship = { name = "HMS Stag" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "D Class" } } }
-
-}
- navy = {
-name = "Dover Patrol"
-location = 3501 # Dover
-base =  3501 # Dover
-ship = { name = "HMS Blake" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Blenham" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Crescent" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Edgar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Endymion" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Gibraltar" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Grafton" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Hawke" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Royal Arthur" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS St. George" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Theseus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Edgar Class" } } }
-ship = { name = "HMS Powerful" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
-ship = { name = "HMS Terrible" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Powerful Class" } } }
-ship = { name = "HMS Amphitrite" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Andromeda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Argonaut" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Ariadne" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Diadem" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Europa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Spartiate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Diadem Class" } } }
-ship = { name = "HMS Aboukir" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Bacchante" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Cressy" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Euryalus" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Hogue" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Adventure" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Attentive" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Forward" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
-ship = { name = "HMS Welland" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Garry" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Foyle" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Itchen" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Arun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Liffey" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Moy" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ouse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Stour" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Test" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Kennet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Jed" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Chelmer" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Colne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ness" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Nith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "Forth Patrol"
-location=351 # Newcastle
-base=351 # Newcastle
-ship = { name = "HMS Pathfinder" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
-ship = { name = "HMS Patrol" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Pathfinder Class" } } }
-ship = { name = "HMS Sentinel" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Sentinel Class" } } }
-ship = { name = "HMS Syren" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Kangaroo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Arab" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Albacore" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Bonetta" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS Star" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Whiting" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Bat" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Crane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Flying Fish" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Fawn" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Flirt" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Bullfinch" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Dove" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Violet" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Sylvia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Avon" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Bittern" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Otter" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Leopard" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Vixen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Brazen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Electra" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Recruit" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Vulture" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Kestrel" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Cheerful" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Mermaid" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Racehorse" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Roebuck" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Gipsy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-ship = { name = "HMS Fairy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ENG version_name = "C Class" } } }
-}
- navy = {
-name = "Northern Patrol"
-location=3379 # Belfast
-base=3379 # Belfast
-ship = { name = "HMS Foresight" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Forward Class" } } }
-}
- navy = {
-name = "11th Cruiser Squadron"
-location=11293 # Cork
-base=11293 # Cork
-ship = { name = "HMS Doris" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Isis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Juno" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Venus" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-}
- navy = {
-name = "12th Cruiser Squadron"
-location = 540 # Plymouth
-base =  540 # Plymouth
-ship = { name = "HMS Charybdis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Eclipse" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Talbot" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Eclipse Class" } } }
-ship = { name = "HMS Pelorus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-}
- navy = {
-name = "1st Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS Holland 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS A2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A12" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-ship = { name = "HMS A13" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "A Class" } } }
-}
- navy = {
-name = "3rd Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS B1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-}
- navy = {
-name = "5th Flotilla"
-location = 9458 # Portsmouth
-base =  9458 # Portsmouth
-ship = { name = "HMS B7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B8" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B9" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B10" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-ship = { name = "HMS B11" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ENG version_name = "B Class" } } }
-}
- navy = {
-name = "6th Flotilla"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS C1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C6" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C7" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-
-}
-
-navy = {
-name = "7th Flotilla"
-location = 6300 # Rosyth
-base =  6300 # Rosyth
-ship = { name = "HMS C9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C13" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C15" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C16" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-
-}
- navy = {
-name = "8th Flotilla"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS C17" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C18" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C19" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C20" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C21" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C22" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C23" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C24" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "9th Flotilla"
-location = 11297 # Hull
-base =  11297 # Hull
-ship = { name = "HMS C25" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C26" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C27" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C28" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C29" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C30" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C31" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C32" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "10th Flotilla"
-location = 540 # Plymouth
-base =  540 # Plymouth
-ship = { name = "HMS D1" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D2" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D3" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D4" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D5" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D6" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D7" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS D8" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E1" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E2" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E3" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E4" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E5" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E6" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E7" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E8" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E9" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS E10" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "9th Cruiser Squadron"
-location=4135 # Gibraltar
-base=4135 # Gibraltar
-ship = { name = "HMS Sutlej" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ENG version_name = "Cressy Class" } } }
-ship = { name = "HMS Vindictive" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Highflyer" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-ship = { name = "HMS Challenger" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-}
- navy = {
-name = "Mediterranean Flotilla"
-location = 12003 # Malta
-base =  12003 # Malta
-ship = { name = "HMS C33" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C34" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C35" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C36" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C37" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS C38" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "Mediterranean Fleet"
-location = 12003 # Malta
-base =  12003 # Malta
-ship = { name = "HMS Indomitable" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Inflexible" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Indefatigable" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Black Prince" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
-ship = { name = "HMS Duke of Edinburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Duke of Edinburgh Class" } } }
-ship = { name = "HMS Warrior" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Warrior Class" } } }
-ship = { name = "HMS Defence" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Minotaur Class" } } }
-ship = { name = "HMS Gloucester" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Bristol Class" } } }
-ship = { name = "HMS Weymouth" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Chatham" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
-ship = { name = "HMS Dublin" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG version_name = "Chatham Class" } } }
-ship = { name = "HMS Beagle" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Bulldog" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Foxhound" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Harpy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Basilisk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Grasshopper" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Mosquito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Scorpion" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Nautilus" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Pincher" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Renard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Wolverine" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Racoon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Rattlesnake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Savage" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Scourge" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Beagle Class" } } }
-ship = { name = "HMS Acorn" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Alarm" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Brisk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Cameleon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Comet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Goldfinch" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Fury" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Hope" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Larne" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Lyra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Martin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Minstrel" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Nemesis" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Nereide" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Nymphe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Redpole" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Rifleman" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Ruby" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Sheldrake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Staunch" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acorn Class" } } }
-ship = { name = "HMS Acheron" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Archer" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Ariel" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Attack" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Badger" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Beaver" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Defender" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Druid" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Ferret" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Forester" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Goshawk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Hind" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Hornet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Hydra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Jackal" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Lapwing" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Lizard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Phoenix" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Sandfly" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Tigress" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Firedrake" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Lurcher" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Oak" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Parramatta" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Yarra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Warrego" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG version_name = "Acheron Class" } } }
-ship = { name = "HMS Acasta" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Achates" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Ambuscade" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Christopher" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Cockatrice" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Contest" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Lynx" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Midge" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Owl" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-ship = { name = "HMS Shark" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "East Indies Squadron"
-location = 10201 # Colombo
-base =  10201 # Colombo
-ship = { name = "HMS Swiftsure" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
-ship = { name = "HMS Fox" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Dartmouth" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG } } }
-}
- navy = {
-name = "China Squadron"
-location=10062 # Hong Kong
-base=10062 # Hong Kong
-ship = { name = "HMS Triumph" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ENG version_name = "Swiftsure Class" } } }
-ship = { name = "HMS Hampshire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-ship = { name = "HMS Roxburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-
-#ship = { name = "HMS Minotaur" definition = battle_cruiser equipment = { battle_cruiser_1890b = { amount = 1 owner = ENG } } }#KiS#version_name = "Minotaur Class" } } }
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+  } }
 
 ship = { name = "HMS Newcastle" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Bristol Class" } } }
 ship = { name = "HMS Yarmouth" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ENG } } }
@@ -1087,42 +1203,10 @@ ship = { name = "HMS Viking" definition = destroyer equipment = { destroyer_1906
 ship = { name = "HMS Zulu" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ENG } } }
 
 }
- navy = {
-name = "N. America & W. Indies Squadron"
-location = 12304 # Kingston
-base =  12304 # Kingston
-ship = { name = "HMS Berwick" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Essex" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Suffolk" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Bristol" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Bristol Class" } } }
-}
- navy = {
-name = "5th Cruiser Squadron"
-location = 2038 # Freetown
-base =  2038 # Freetown
-ship = { name = "HMS Cornwall" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Cumberland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Donegal" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Lancaster" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Monmouth" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Carnarvon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Devonshire Class" } } }
-
-}
- navy = {
-name = "S.E. Coast of America Squadron"
-location = 12960 # Falkland Islands
-base =  12960 # Falkland Islands
-ship = { name = "HMS Kent" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = ENG version_name = "Monmouth Class" } } }
-ship = { name = "HMS Glasgow" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ENG version_name = "Bristol Class" } } }
-}
- navy = {
-name = "Cape Squadron"
-location=12589 # Cape Town
-base=12589 # Cape Town
-ship = { name = "HMS Astraea" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Astraea Class" } } }
-ship = { name = "HMS Hyacinth" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Hermes Class" } } }
-ship = { name = "HMS Pegasus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-}
+ 
+ 
+ 
+ 
 
 
 }

--- a/mod/thegreatwar/history/units/EST_army.txt
+++ b/mod/thegreatwar/history/units/EST_army.txt
@@ -15,6 +15,29 @@ division_template = {
 }
 
 units = {
+
+fleet = {
+	name = "I Eesti Sojalaevastik Fleet"
+	naval_base = 3152
+	task_force = {
+		name = "I Eesti Sojalaevastik"
+		location = 3152
+		ship = { name = "EML Kalev" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }
+		ship = { name = "EML Lembit" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }
+	}
+}
+
+fleet = {
+	name = "II Eesti Sojalaevastik Fleet"
+	naval_base = 9340
+	task_force = {
+		name = "II Eesti Sojalaevastik"
+		location = 9340
+		ship = { name = "EML Tasuja" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }
+		ship = { name = "EML Ilmatar" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }
+	}
+}
+
 	######## LAND OOB ########
 	##### Eesti Ülemjuhatus #####
 	division = {
@@ -82,20 +105,8 @@ units = {
 	}
 
 	##### NAVAL OOB #####
-	navy = {				
-		name = "I Eesti Sojalaevastik"			
-		base = 3152 
-		location = 3152  # Tallinn
-		#ship = { name = "EML Kalev" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }			
-		#ship = { name = "EML Lembit" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }		
-	}
-	navy = {					
-		name = "II Eesti Sojalaevastik"				
-		base = 9340
-		location =  9340 # Riga
-		#ship = { name = "EML Tasuja" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }
-		#ship = { name = "EML Ilmatar" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = EST } } }
-	}
+	
+	
 }
 
 ### Starting Production ###

--- a/mod/thegreatwar/history/units/FRA_1910.txt
+++ b/mod/thegreatwar/history/units/FRA_1910.txt
@@ -115,6 +115,296 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "1ère Armée Navale Fleet"
+	naval_base = 911 # Toulon
+	task_force = {
+		name = "1ère Armée Navale"
+		location = 911 # Toulon
+		ship = { name = "Furieux" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Furieux Class" } } }
+		ship = { name = "Achéron" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
+		ship = { name = "Cocyte" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
+		ship = { name = "Styx" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
+		ship = { name = "Jemmapes" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jemmapes Class" } } }
+		ship = { name = "Valmy" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jemmapes Class" } } }
+		ship = { name = "Bouvines" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
+		ship = { name = "Amiral Tréhouart" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
+		ship = { name = "Dévastation" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Courbet Class" } } }
+		ship = { name = "Terrible" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
+		ship = { name = "Indomptable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
+		ship = { name = "Caïman" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
+		ship = { name = "Requin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
+		ship = { name = "Formidable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Amiral Baudin Class" } } }
+		ship = { name = "Hoche" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Hoche Class" } } }
+		ship = { name = "Marceau" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Marceau Class" } } }
+		ship = { name = "Neptune" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Marceau Class" } } }
+		ship = { name = "Brennus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Brennus Class" } } }
+		ship = { name = "Charles Martel" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charles Martel Class" } } }
+		ship = { name = "Carnot" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Carnot Class" } } }
+		ship = { name = "Jauréguiberry" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jauréguiberry Class" } } }
+		ship = { name = "Masséna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Masséna Class" } } }
+		ship = { name = "Bouvet" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvet Class" } } }
+		ship = { name = "Charlemagne" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
+		ship = { name = "Gaulois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
+		ship = { name = "St. Louis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
+		ship = { name = "Henri IV" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Suffren" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Suffren Class" } } }
+		ship = { name = "République" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
+		ship = { name = "Patrie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
+		ship = { name = "Démocratie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
+		ship = { name = "Justice" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
+		ship = { name = "Liberté" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
+		ship = { name = "Verité" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
+		ship = { name = "Ernest Renan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Ernest Renan Class" } } }
+		ship = { name = "Edgar Quinet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
+		ship = { name = "Waldeck-Rousseau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
+		ship = { name = "Léon Gambetta" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
+		ship = { name = "Jules Ferry" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
+		ship = { name = "Victor Hugo" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
+		ship = { name = "Jules Michelet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jules Michelet Class" } } }
+		ship = { name = "Bruix" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
+		ship = { name = "Latouche-Tréville" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
+		ship = { name = "Pothuau" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Pothuau Class" } } }
+		ship = { name = "D'Entrecasteaux" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Entrecasteaux Class" } } }
+		ship = { name = "Tromblon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Pierrier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Obusier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mortier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Claymore" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Carquois" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Trident" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Fleuret" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Coutelas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Cognee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Hache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Massue" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Glaive" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Poignard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Sabretache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Oriflamme" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Etendard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Fanion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Sape" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Gabion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Branlebas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Fanfare" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Spahi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Hussard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Carabinier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Lansquenet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mameluk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Voltigeur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
+		ship = { name = "Tirailleur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
+		ship = { name = "Chasseur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
+		ship = { name = "Janissaire" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
+		ship = { name = "Fantassin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
+	}
+	task_force = {
+		name = "3ème Division de Sous-Marins"
+		location = 911 # Toulon
+		ship = { name = "Esturgeon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Grondin  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Loutre " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Ludion " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Lynx" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Meduse " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Naiade " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Otarie" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Oursin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Perle " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Phoque" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Protee " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Souffleur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Thon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Truite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "X " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "X Class" } } }
+		ship = { name = "Aigrette" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Cigogne" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Omega" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Omega Class" } } }
+		ship = { name = "Emeraude" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Opale" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Rubis" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Saphir" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Topase" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Turquoise" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Calypso " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
+		ship = { name = "Circe " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
+		ship = { name = "Ampere " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Berthelot " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Cugnot  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Floreal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Fresnel " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Fructidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Gay - Lussac  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Germinal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Giffard  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Messidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Monge " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Papin " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Pluviose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Prairial " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Thermidor  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Vendemiaire " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Ventose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Watt  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Archimede" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA } } }
+	}
+}
+
+fleet = {
+	name = "2ème Division Légére Fleet"
+	naval_base = 6449 # Cherbourg
+	task_force = {
+		name = "2ème Division Légére"
+		location = 6449 # Cherbourg
+		ship = { name = "Amiral Aube" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Condé" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Gloire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Marseillaise" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Desaix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Kléber" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Jeanne D'Arc" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Jeanne D'Arc Class" } } }
+		ship = { name = "Dupetit-Thouars" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
+		ship = { name = "Gueydon" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
+		ship = { name = "Lavoisier" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Linois Class" } } }
+		ship = { name = "Forbin" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
+		ship = { name = "Épervier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Faucon" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Bombe" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
+		ship = { name = "Couleuvrine" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
+		ship = { name = "Flèche" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
+		ship = { name = "Lance" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
+		ship = { name = "Sainte-Barbe" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
+		ship = { name = "Casabianca" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Cassini" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "D'Iberville" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Dunois" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
+		ship = { name = "La Hire" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
+		ship = { name = "Foudre" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Foudre Class" } } }
+		ship = { name = "Amiral Cécille" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Amiral Cécille Class" } } }
+		ship = { name = "Isly" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Alger Class" } } }
+		ship = { name = "Friant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Friant Class" } } }
+		ship = { name = "Du Chayla" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
+		ship = { name = "Châteaurenault" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Châteaurenault Class" } } }
+		ship = { name = "Jurien De La Gravière" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jurien De La Gravière Class" } } }
+		ship = { name = "Alger" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Alger Class" } } }
+		ship = { name = "Galilée" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Linois Class" } } }
+		ship = { name = "Chasseloup-Laubat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Friant Class" } } }
+		ship = { name = "Pascal" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Descartes Class" } } }
+		ship = { name = "Catinat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Catinat Class" } } }
+		ship = { name = "D'Estrées" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Estrées Class" } } }
+		ship = { name = "Infernet" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Estrées Class" } } }
+		ship = { name = "Surcouf" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
+		ship = { name = "Lalande" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Troude Class" } } }
+		ship = { name = "Guichen" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Guichen Class" } } }
+		ship = { name = "Pertuisane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Escopette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Flamberge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Rapiere" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Carabine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Sarbacane" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Arquebuse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Arbalete" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mousquet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Javeline" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Sagaie" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Epieu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Harpon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Fronde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Francisque" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Sabre" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Dard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Baliste" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mousqueton" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Arc" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Pistolet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Belier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Catapulte" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Bombarde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Stylet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+	}
+	task_force = {
+		name = "1ère Division de Sous-Marins"
+		location = 6449 # Cherbourg
+		ship = { name = "Plongeur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Espadon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Silure  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Sirene " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Triton  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Farfadet " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Farfadet Class" } } }
+	}
+}
+
+fleet = {
+	name = "2ème Division de Sous-Marins Fleet"
+	naval_base = 575 # Calais
+	task_force = {
+		name = "Défense Mobile"
+		location = 575 # Calais
+		ship = { name = "Durandal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Hallebarde" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Fauconneau" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Yatagan" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
+		ship = { name = "Pique" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
+		ship = { name = "Epee" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
+	}
+	task_force = {
+		name = "2ème Division de Sous-Marins"
+		location = 575 # Calais
+		ship = { name = "Algerien" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
+		ship = { name = "Francais  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
+		ship = { name = "Alose" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Anguille " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Bonite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Castor " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Dorade" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+	}
+}
+
+fleet = {
+	name = "Détail Speciale Fleet"
+	naval_base = 7069 # Casablanca
+	task_force = {
+		name = "Détail Speciale"
+		location = 7069 # Casablanca
+		ship = { name = "Dupuy de Lôme" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Amiral Charner" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
+		ship = { name = "Cassard" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
+		ship = { name = "Cosmao" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Troude Class" } } }
+	}
+}
+
+fleet = {
+	name = "Détail Orientale Fleet"
+	naval_base = 4401 # Saigon
+	task_force = {
+		name = "Détail Orientale"
+		location = 4401 # Saigon
+		ship = { name = "Dupleix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
+	}
+}
+
+fleet = {
+	name = "Détail des Indes de l'Ouest Fleet"
+	naval_base = 9377 # Guadeloupe
+	task_force = {
+		name = "Détail des Indes de l'Ouest"
+		location = 9377 # Guadeloupe
+		ship = { name = "Descartes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Descartes Class" } } }
+	}
+}
+
+fleet = {
+	name = "Détail du Pacifique de Sud Fleet"
+	naval_base = 12148 # Tahiti
+	task_force = {
+		name = "Détail du Pacifique de Sud"
+		location = 12148 # Tahiti
+		ship = { name = "Montcalm" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
+	}
+}
+
 	division= { 
 			name = "81eme Division d'Infanterie territoriale"
 			location=11548 # Calais
@@ -1221,280 +1511,16 @@ units = {
 			division_template="Troupes Coloniales"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "1ère Armée Navale"
-		location = 911 # Toulon
-		base =  911 # Toulon
-ship = { name = "Furieux" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Furieux Class" } } }
-ship = { name = "Achéron" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
-ship = { name = "Cocyte" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
-ship = { name = "Styx" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
-ship = { name = "Jemmapes" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jemmapes Class" } } }
-ship = { name = "Valmy" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jemmapes Class" } } }
-ship = { name = "Bouvines" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
-ship = { name = "Amiral Tréhouart" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
-ship = { name = "Dévastation" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Courbet Class" } } }
-ship = { name = "Terrible" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
-ship = { name = "Indomptable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
-ship = { name = "Caïman" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
-ship = { name = "Requin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
-ship = { name = "Formidable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Amiral Baudin Class" } } }
-ship = { name = "Hoche" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Hoche Class" } } }
-ship = { name = "Marceau" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Marceau Class" } } }
-ship = { name = "Neptune" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Marceau Class" } } }
-ship = { name = "Brennus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Brennus Class" } } }
-ship = { name = "Charles Martel" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charles Martel Class" } } }
-ship = { name = "Carnot" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Carnot Class" } } }
-ship = { name = "Jauréguiberry" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jauréguiberry Class" } } }
-ship = { name = "Masséna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Masséna Class" } } }
-ship = { name = "Bouvet" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvet Class" } } }
-ship = { name = "Charlemagne" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
-ship = { name = "Gaulois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
-ship = { name = "St. Louis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
-ship = { name = "Henri IV" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Suffren" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Suffren Class" } } }
-ship = { name = "République" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
-ship = { name = "Patrie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
-ship = { name = "Démocratie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
-ship = { name = "Justice" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
-ship = { name = "Liberté" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
-ship = { name = "Verité" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
-ship = { name = "Ernest Renan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Ernest Renan Class" } } }
-ship = { name = "Edgar Quinet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
-ship = { name = "Waldeck-Rousseau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
-ship = { name = "Léon Gambetta" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
-ship = { name = "Jules Ferry" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
-ship = { name = "Victor Hugo" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
-ship = { name = "Jules Michelet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jules Michelet Class" } } }
-ship = { name = "Bruix" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
-ship = { name = "Latouche-Tréville" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
-ship = { name = "Pothuau" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Pothuau Class" } } }
-ship = { name = "D'Entrecasteaux" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Entrecasteaux Class" } } }
-ship = { name = "Tromblon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Pierrier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Obusier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Mortier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Claymore" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Carquois" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Trident" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Fleuret" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Coutelas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Cognee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Hache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Massue" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Glaive" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Poignard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Sabretache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Oriflamme" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Etendard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Fanion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Sape" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Gabion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Branlebas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Fanfare" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Spahi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Hussard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Carabinier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Lansquenet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Mameluk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Voltigeur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
-ship = { name = "Tirailleur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
-ship = { name = "Chasseur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
-ship = { name = "Janissaire" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
-ship = { name = "Fantassin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
-
-		}
-	 navy = {
-		name = "2ème Division Légére"
-		location=6449 # Cherbourg
-		base=6449 # Cherbourg
-ship = { name = "Amiral Aube" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Condé" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Gloire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Marseillaise" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Desaix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Kléber" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Jeanne D'Arc" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Jeanne D'Arc Class" } } }
-ship = { name = "Dupetit-Thouars" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
-ship = { name = "Gueydon" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
-ship = { name = "Lavoisier" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Linois Class" } } }
-ship = { name = "Forbin" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
-ship = { name = "Épervier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Faucon" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Bombe" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
-ship = { name = "Couleuvrine" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
-ship = { name = "Flèche" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
-ship = { name = "Lance" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
-ship = { name = "Sainte-Barbe" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
-ship = { name = "Casabianca" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Cassini" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "D'Iberville" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Dunois" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
-ship = { name = "La Hire" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
-ship = { name = "Foudre" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Foudre Class" } } }
-ship = { name = "Amiral Cécille" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Amiral Cécille Class" } } }
-ship = { name = "Isly" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Alger Class" } } }
-ship = { name = "Friant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Friant Class" } } }
-ship = { name = "Du Chayla" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
-ship = { name = "Châteaurenault" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Châteaurenault Class" } } }
-ship = { name = "Jurien De La Gravière" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jurien De La Gravière Class" } } }
-ship = { name = "Alger" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Alger Class" } } }
-ship = { name = "Galilée" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Linois Class" } } }
-ship = { name = "Chasseloup-Laubat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Friant Class" } } }
-ship = { name = "Pascal" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Descartes Class" } } }
-ship = { name = "Catinat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Catinat Class" } } }
-ship = { name = "D'Estrées" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Estrées Class" } } }
-ship = { name = "Infernet" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Estrées Class" } } }
-ship = { name = "Surcouf" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
-ship = { name = "Lalande" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Troude Class" } } }
-ship = { name = "Guichen" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Guichen Class" } } }
-ship = { name = "Pertuisane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Escopette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Flamberge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Rapiere" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Carabine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Sarbacane" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Arquebuse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Arbalete" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Mousquet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Javeline" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Sagaie" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Epieu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Harpon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Fronde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Francisque" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Sabre" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Dard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Baliste" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Mousqueton" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Arc" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Pistolet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Belier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Catapulte" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Bombarde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Stylet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-
-		}
-	 navy = {
-		name = "Défense Mobile"
-		location=575 # Calais
-		base=575 # Calais
-ship = { name = "Durandal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Hallebarde" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Fauconneau" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Yatagan" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
-ship = { name = "Pique" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
-ship = { name = "Epee" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
-
-
-		}
-	 navy = {
-		name = "Détail Speciale"
-		location=7069 # Casablanca
-		base=7069 # Casablanca
-ship = { name = "Dupuy de Lôme" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Amiral Charner" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
-ship = { name = "Cassard" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
-ship = { name = "Cosmao" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Troude Class" } } }
-
-		}
-	 navy = {
-		name = "Détail Orientale"
-		location=4401 # Saigon
-		base=4401 # Saigon
-ship = { name = "Dupleix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
-		}
-	 navy = {
-		name = "Détail des Indes de l'Ouest"
-		location = 9377 # Guadeloupe
-		base =  9377 # Guadeloupe
-ship = { name = "Descartes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Descartes Class" } } }
-
-		}
-	 navy = {
-		name = "Détail du Pacifique de Sud"
-		location = 12148 # Tahiti
-		base =  12148 # Tahiti
-		ship = { name = "Montcalm" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
-
-		}
-	 navy = {
-		name = "1ère Division de Sous-Marins"
-		location=6449 # Cherbourg
-		base=6449 # Cherbourg
-ship = { name = "Plongeur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Espadon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Silure  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Sirene " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Triton  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Farfadet " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Farfadet Class" } } }
-
-		}
-	 navy = {
-		name = "2ème Division de Sous-Marins"
-		location=575 # Calais
-		base=575 # Calais
-ship = { name = "Algerien" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
-ship = { name = "Francais  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
-ship = { name = "Alose" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Anguille " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Bonite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Castor " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Dorade" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-
-		}
-	 navy = {
-		name = "3ème Division de Sous-Marins"
-		location = 911 # Toulon
-		base =  911 # Toulon
-ship = { name = "Esturgeon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Grondin  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Loutre " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Ludion " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Lynx" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Meduse " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Naiade " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Otarie" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Oursin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Perle " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Phoque" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Protee " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Souffleur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Thon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Truite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "X " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "X Class" } } }
-ship = { name = "Aigrette" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Cigogne" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Omega" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Omega Class" } } }
-ship = { name = "Emeraude" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Opale" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Rubis" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Saphir" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Topase" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Turquoise" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Calypso " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
-ship = { name = "Circe " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
-ship = { name = "Ampere " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Berthelot " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Cugnot  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Floreal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Fresnel " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Fructidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Gay - Lussac  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Germinal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Giffard  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Messidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Monge " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Papin " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Pluviose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Prairial " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Thermidor  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Vendemiaire " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Ventose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Watt  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Archimede" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA } } }
-
-		}
+	 
+	 
+	 
+	 
+	 
+	 
+	 
+	 
+	 
+	 
 
 	}
 air_wings = { 

--- a/mod/thegreatwar/history/units/FRA_1914.txt
+++ b/mod/thegreatwar/history/units/FRA_1914.txt
@@ -116,6 +116,331 @@ division_template = {
 ###################################################################
 	
 units = {
+
+fleet = {
+	name = "Groupe des Indes de l'Ouest Fleet"
+	naval_base = 9377 # Guadeloupe
+	task_force = {
+		name = "Groupe des Indes de l'Ouest"
+		location = 9377 # Guadeloupe
+		ship = { name = "Descartes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Descartes Class" } } }
+	}
+}
+
+fleet = {
+	name = "2e Division Loire Fleet"
+	naval_base = 6449 # Cherbourg
+	task_force = {
+		name = "2e Division Loire"
+		location = 6449 # Cherbourg
+		ship = { name = "Amiral Aube" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Condé" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Gloire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Marseillaise" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
+		ship = { name = "Desaix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Kléber" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Jeanne D'Arc" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Jeanne D'Arc Class" } } }
+		ship = { name = "Dupetit-Thouars" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
+		ship = { name = "Gueydon" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
+		ship = { name = "Lavoisier" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Linois Class" } } }
+		ship = { name = "Isly" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Alger Class" } } }
+		ship = { name = "Forbin" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
+		ship = { name = "Faucon" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Lance" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
+		ship = { name = "Casabianca" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Cassini" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "D'Iberville" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Dunois" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
+		ship = { name = "La Hire" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
+		ship = { name = "Amiral Cécille" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Amiral Cécille Class" } } }
+		ship = { name = "Friant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Friant Class" } } }
+		ship = { name = "Du Chayla" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
+		ship = { name = "Châteaurenault" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Châteaurenault Class" } } }
+		ship = { name = "D'Estrées" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Estrées Class" } } }
+		ship = { name = "Jurien De La Gravière" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jurien De La Gravière Class" } } }
+		ship = { name = "Surcouf" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
+		ship = { name = "Guichen" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Guichen Class" } } }
+		ship = { name = "Durandal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Hallebarde" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Fauconneau" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Yatagan" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
+		ship = { name = "Pique" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
+		ship = { name = "Epee" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
+		ship = { name = "Pertuisane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Escopette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Flamberge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Rapiere" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
+		ship = { name = "Carabine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Sarbacane" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Arquebuse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Arbalete" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mousquet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Javeline" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Sagaie" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Epieu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Harpon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Fronde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Francisque" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Sabre" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Dard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Baliste" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mousqueton" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+	}
+	task_force = {
+		name = "1re Division de Sous-Marins"
+		location = 6449 # Cherbourg
+		ship = { name = "Plongeur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Espadon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Silure  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Sirene " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Triton  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
+		ship = { name = "Algerien" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
+		ship = { name = "Francais  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
+	}
+}
+
+fleet = {
+	name = "Defense Mobile Fleet"
+	naval_base = 575 # Calais
+	task_force = {
+		name = "Defense Mobile"
+		location = 575 # Calais
+		ship = { name = "Arc" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Pistolet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Belier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Catapulte" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Bombarde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Stylet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Tromblon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Pierrier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Obusier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mortier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Claymore" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Carquois" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Trident" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Fleuret" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Coutelas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Cognee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Hache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Massue" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
+		ship = { name = "Glaive" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Poignard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Sabretache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Oriflamme" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Etendard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Fanion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Sape" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+	}
+	task_force = {
+		name = "2e Division de Sous-Marins"
+		location = 575 # Calais
+		ship = { name = "Alose" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Anguille " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Bonite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Castor " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Dorade" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Esturgeon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Grondin  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Loutre " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Ludion " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+	}
+}
+
+fleet = {
+	name = "1er ArmeeNavale Fleet"
+	naval_base = 911 # Toulon
+	task_force = {
+		name = "1er ArmeeNavale"
+		location = 911 # Toulon
+		ship = { name = "Courbet" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Jean Bart" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Condorcet" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
+		ship = { name = "Danton" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
+		ship = { name = "Diderot" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
+		ship = { name = "Mirabeau" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
+		ship = { name = "Vergniaud" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
+		ship = { name = "Voltaire" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
+		ship = { name = "Démocratie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
+		ship = { name = "Justice" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
+		ship = { name = "Verité" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
+		ship = { name = "Suffren" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Suffren Class" } } }
+		ship = { name = "République" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
+		ship = { name = "Patrie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
+		ship = { name = "Bouvet" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvet Class" } } }
+		ship = { name = "Charlemagne" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
+		ship = { name = "Gaulois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
+		ship = { name = "St. Louis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
+		ship = { name = "Henri IV" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA } } }
+		ship = { name = "Charles Martel" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charles Martel Class" } } }
+		ship = { name = "Carnot" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Carnot Class" } } }
+		ship = { name = "Jauréguiberry" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jauréguiberry Class" } } }
+		ship = { name = "Masséna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Masséna Class" } } }
+		ship = { name = "Indomptable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
+		ship = { name = "Caïman" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
+		ship = { name = "Requin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
+		ship = { name = "Marceau" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Marceau Class" } } }
+		ship = { name = "Brennus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Brennus Class" } } }
+		ship = { name = "Styx" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
+		ship = { name = "Bouvines" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
+		ship = { name = "Amiral Tréhouart" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
+		ship = { name = "Dévastation" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Courbet Class" } } }
+		ship = { name = "Ernest Renan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Ernest Renan Class" } } }
+		ship = { name = "Edgar Quinet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
+		ship = { name = "Waldeck-Rousseau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
+		ship = { name = "Léon Gambetta" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
+		ship = { name = "Jules Ferry" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
+		ship = { name = "Victor Hugo" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
+		ship = { name = "Jules Michelet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jules Michelet Class" } } }
+		ship = { name = "Bruix" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
+		ship = { name = "Latouche-Tréville" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
+		ship = { name = "Pothuau" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Pothuau Class" } } }
+		ship = { name = "D'Entrecasteaux" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Entrecasteaux Class" } } }
+		ship = { name = "Gabion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Branlebas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Fanfare" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+		ship = { name = "Spahi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Hussard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Carabinier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Lansquenet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mameluk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Ensigne Henry" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Aspirant Herber" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Voltigeur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
+		ship = { name = "Tirailleur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
+		ship = { name = "Chasseur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
+		ship = { name = "Janissaire" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
+		ship = { name = "Fantassin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
+		ship = { name = "Cavalier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
+		ship = { name = "Bouclier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Boutefeu" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Casque" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Cimeterre" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Dague" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Faulx" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Fourche" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Capitaine Mehl" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Commandant Bory" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Commandant Riviere" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Dehorter" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Francis Garnier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
+		ship = { name = "Bisson" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Renaudin" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Protet" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mangini" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Magon" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Opiniatre" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
+		ship = { name = "Aventurier" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
+		ship = { name = "Temeraire" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
+		ship = { name = "Intrepide" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
+		ship = { name = "Foudre" definition = carrier equipment = { carrier_1914 = { amount = 1 owner = FRA } } 
+
+			air_wings = {
+				ww1_seaplane_equipment_1 =  { owner = "FRA" amount = 4 }
+			}
+		}
+	}
+	task_force = {
+		name = "3e Division de Sous-Marins"
+		location = 911 # Toulon
+		ship = { name = "Lynx" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Meduse " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Naiade " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Otarie" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Oursin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Perle " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Phoque" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Protee " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Souffleur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Thon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "Truite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
+		ship = { name = "X " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "X Class" } } }
+		ship = { name = "Aigrette" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Cigogne" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
+		ship = { name = "Omega" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Omega Class" } } }
+		ship = { name = "Emeraude" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Opale" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Rubis" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Saphir" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Topase" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Turquoise" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
+		ship = { name = "Calypso " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
+		ship = { name = "Circe " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
+		ship = { name = "Ampere " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Berthelot " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Cugnot  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Floreal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Fresnel " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Fructidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Gay - Lussac  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Germinal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Giffard  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Messidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Monge " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Papin " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Pluviose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Prairial " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Thermidor  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Ventose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Watt  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
+		ship = { name = "Arago " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Bernouilli  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Brumaire" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Coulomb  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Curie  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Euler" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Faraday  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Foucault  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Franklin " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Frimarie " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Joule " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Le Verrier  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Montgolfier " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Newton  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Nivose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Volta  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
+		ship = { name = "Archimede" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA } } }
+		ship = { name = "Mariotte" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Mariotte Class" } } }
+		ship = { name = "Amiral Bourgois " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Amiral Bourgois Class" } } }
+		ship = { name = "Charles Brun " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Charles Brun Class" } } }
+		ship = { name = "Clorinde " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Clorinde Class" } } }
+		ship = { name = "Cornelei " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Clorinde Class" } } }
+		ship = { name = "Gustave Zede " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Gustave Zede Class" } } }
+	}
+}
+
+fleet = {
+	name = "Groupe Speciale Fleet"
+	naval_base = 7069 # Casablanca
+	task_force = {
+		name = "Groupe Speciale"
+		location = 7069 # Casablanca
+		ship = { name = "Dupuy de Lôme" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA } } }
+		ship = { name = "Amiral Charner" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
+		ship = { name = "Cassard" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
+		ship = { name = "Cosmao" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Troude Class" } } }
+	}
+}
+
+fleet = {
+	name = "Orientale Fleet"
+	naval_base = 4401 # Saigon
+	task_force = {
+		name = "Orientale"
+		location = 4401 # Saigon
+		ship = { name = "Dupleix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
+	}
+}
+
+fleet = {
+	name = "Groupe du Pacifique de Sud Fleet"
+	naval_base = 12148 # Tahiti
+	task_force = {
+		name = "Groupe du Pacifique de Sud"
+		location = 12148 # Tahiti
+		ship = { name = "Montcalm" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
+	}
+}
+
 	division= { 
 			name = "81eme Division d'Infanterie territoriale"
 			location=11548 # Calais
@@ -1489,316 +1814,18 @@ units = {
 			start_manpower_factor = 0.3
 			}			
 			
-	 navy = {
-		name = "2e Division Loire"
-		location=6449 # Cherbourg
-		base=6449 # Cherbourg
-ship = { name = "Amiral Aube" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Condé" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Gloire" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Marseillaise" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Gloire Class" } } }
-ship = { name = "Desaix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Kléber" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Jeanne D'Arc" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Jeanne D'Arc Class" } } }
-ship = { name = "Dupetit-Thouars" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
-ship = { name = "Gueydon" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
-ship = { name = "Lavoisier" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Linois Class" } } }
-ship = { name = "Isly" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Alger Class" } } }
-ship = { name = "Forbin" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
-ship = { name = "Faucon" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Lance" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = FRA version_name = "Bombe Class" } } }
-ship = { name = "Casabianca" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Cassini" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "D'Iberville" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Dunois" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
-ship = { name = "La Hire" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Dunois Class" } } }
-ship = { name = "Amiral Cécille" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Amiral Cécille Class" } } }
-ship = { name = "Friant" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Friant Class" } } }
-ship = { name = "Du Chayla" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
-ship = { name = "Châteaurenault" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Châteaurenault Class" } } }
-ship = { name = "D'Estrées" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Estrées Class" } } }
-ship = { name = "Jurien De La Gravière" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jurien De La Gravière Class" } } }
-ship = { name = "Surcouf" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Forbin Class" } } }
-ship = { name = "Guichen" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Guichen Class" } } }
-ship = { name = "Durandal" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Hallebarde" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Fauconneau" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Yatagan" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
-ship = { name = "Pique" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
-ship = { name = "Epee" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Framee Class" } } }
-ship = { name = "Pertuisane" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Escopette" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Flamberge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Rapiere" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = FRA version_name = "Pertuisane Class" } } }
-ship = { name = "Carabine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Sarbacane" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Arquebuse" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Arbalete" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Mousquet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Javeline" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Sagaie" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Epieu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Harpon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Fronde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Francisque" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Sabre" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Dard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Baliste" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Mousqueton" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
+	 
+	 
+	 
+	 
 
-}
-	 navy = {
-		name = "Defense Mobile"
-		location=575 # Calais
-		base=575 # Calais
-ship = { name = "Arc" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Pistolet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Belier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Catapulte" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Bombarde" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Stylet" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Tromblon" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Pierrier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Obusier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Mortier" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Claymore" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Carquois" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Trident" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Fleuret" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Coutelas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Cognee" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Hache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Massue" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Claymore Class" } } }
-ship = { name = "Glaive" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Poignard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Sabretache" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Oriflamme" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Etendard" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Fanion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Sape" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
+	 
+	 
+	 
 
-}
-	 navy = {
-		name = "1re Division de Sous-Marins"
-		location=6449 # Cherbourg
-		base=6449 # Cherbourg
-ship = { name = "Plongeur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Espadon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Silure  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Sirene " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Triton  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Sirene Class" } } }
-ship = { name = "Algerien" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
-ship = { name = "Francais  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Morse Class" } } }
-
-}
-	 navy = {
-		name = "2e Division de Sous-Marins"
-		location=575 # Calais
-		base=575 # Calais
-ship = { name = "Alose" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Anguille " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Bonite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Castor " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Dorade" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Esturgeon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Grondin  " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Loutre " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Ludion " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-
-}
-
-	 navy = {
-		name = "1er ArmeeNavale"
-		location = 911 # Toulon
-		base =  911 # Toulon
-ship = { name = "Courbet" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Jean Bart" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Condorcet" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
-ship = { name = "Danton" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
-ship = { name = "Diderot" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
-ship = { name = "Mirabeau" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
-ship = { name = "Vergniaud" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
-ship = { name = "Voltaire" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Danton Class" } } }
-ship = { name = "Démocratie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
-ship = { name = "Justice" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
-ship = { name = "Verité" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Liberté Class" } } }
-ship = { name = "Suffren" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "Suffren Class" } } }
-ship = { name = "République" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
-ship = { name = "Patrie" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA version_name = "République Class" } } }
-ship = { name = "Bouvet" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvet Class" } } }
-ship = { name = "Charlemagne" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
-ship = { name = "Gaulois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
-ship = { name = "St. Louis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charlemagne Class" } } }
-ship = { name = "Henri IV" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = FRA } } }
-ship = { name = "Charles Martel" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Charles Martel Class" } } }
-ship = { name = "Carnot" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Carnot Class" } } }
-ship = { name = "Jauréguiberry" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Jauréguiberry Class" } } }
-ship = { name = "Masséna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Masséna Class" } } }
-ship = { name = "Indomptable" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
-ship = { name = "Caïman" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
-ship = { name = "Requin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Terrible Class" } } }
-ship = { name = "Marceau" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Marceau Class" } } }
-ship = { name = "Brennus" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Brennus Class" } } }
-ship = { name = "Styx" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Achéron Class" } } }
-ship = { name = "Bouvines" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
-ship = { name = "Amiral Tréhouart" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Bouvines Class" } } }
-ship = { name = "Dévastation" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = FRA version_name = "Courbet Class" } } }
-ship = { name = "Ernest Renan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Ernest Renan Class" } } }
-ship = { name = "Edgar Quinet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
-ship = { name = "Waldeck-Rousseau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Edgar Quinet Class" } } }
-ship = { name = "Léon Gambetta" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
-ship = { name = "Jules Ferry" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
-ship = { name = "Victor Hugo" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Léon Gambetta Class" } } }
-ship = { name = "Jules Michelet" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA version_name = "Jules Michelet Class" } } }
-ship = { name = "Bruix" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
-ship = { name = "Latouche-Tréville" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
-ship = { name = "Pothuau" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Pothuau Class" } } }
-ship = { name = "D'Entrecasteaux" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Entrecasteaux Class" } } }
-ship = { name = "Gabion" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Branlebas" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Fanfare" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = FRA version_name = "Branlebas Class" } } }
-ship = { name = "Spahi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Hussard" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Carabinier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Lansquenet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Mameluk" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Ensigne Henry" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Aspirant Herber" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Voltigeur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
-ship = { name = "Tirailleur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Voltigeur Class" } } }
-ship = { name = "Chasseur" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
-ship = { name = "Janissaire" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
-ship = { name = "Fantassin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
-ship = { name = "Cavalier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Chasseur Class" } } }
-ship = { name = "Bouclier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Boutefeu" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Casque" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Cimeterre" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Dague" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Faulx" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Fourche" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Capitaine Mehl" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Commandant Bory" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Commandant Riviere" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Dehorter" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Francis Garnier" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = FRA version_name = "Bouclier Class" } } }
-ship = { name = "Bisson" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Renaudin" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Protet" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Mangini" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Magon" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Opiniatre" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
-ship = { name = "Aventurier" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
-ship = { name = "Temeraire" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
-ship = { name = "Intrepide" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = FRA version_name = "Aventurier Class" } } }
-ship = { name = "Foudre" definition = carrier equipment = { carrier_1914 = { amount = 1 owner = FRA } } 
-
-			air_wings = {
-				ww1_seaplane_equipment_1 =  { owner = "FRA" amount = 4 }
-			}
-		}
-
-
-}
-	 navy = {
-		name = "3e Division de Sous-Marins"
-		location = 911 # Toulon
-		base =  911 # Toulon
-ship = { name = "Lynx" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Meduse " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Naiade " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Otarie" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Oursin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Perle " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Phoque" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Protee " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Souffleur" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Thon " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "Truite " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "Naiade Class" } } }
-ship = { name = "X " definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = FRA version_name = "X Class" } } }
-ship = { name = "Aigrette" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Cigogne" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA } } }
-ship = { name = "Omega" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Omega Class" } } }
-ship = { name = "Emeraude" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Opale" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Rubis" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Saphir" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Topase" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Turquoise" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Emeraude Class" } } }
-ship = { name = "Calypso " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
-ship = { name = "Circe " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Circe Class" } } }
-ship = { name = "Ampere " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Berthelot " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Cugnot  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Floreal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Fresnel " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Fructidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Gay - Lussac  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Germinal " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Giffard  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Messidor " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Monge " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Papin " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Pluviose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Prairial " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Thermidor  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Ventose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Watt  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Pluviose Class" } } }
-ship = { name = "Arago " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Bernouilli  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Brumaire" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Coulomb  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Curie  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Euler" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Faraday  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Foucault  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Franklin " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Frimarie " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Joule " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Le Verrier  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Montgolfier " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Newton  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Nivose " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Volta  " definition = submarine equipment = { submarine_1910 = { amount = 1 owner = FRA version_name = "Brumaire Class" } } }
-ship = { name = "Archimede" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA } } }
-ship = { name = "Mariotte" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Mariotte Class" } } }
-ship = { name = "Amiral Bourgois " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Amiral Bourgois Class" } } }
-ship = { name = "Charles Brun " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Charles Brun Class" } } }
-ship = { name = "Clorinde " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Clorinde Class" } } }
-ship = { name = "Cornelei " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Clorinde Class" } } }
-ship = { name = "Gustave Zede " definition = submarine equipment = { submarine_1906 = { amount = 1 owner = FRA version_name = "Gustave Zede Class" } } }
-
-}
-	 navy = {
-		name = "Groupe Speciale"
-		location=7069 # Casablanca
-		base=7069 # Casablanca
-ship = { name = "Dupuy de Lôme" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA } } }
-ship = { name = "Amiral Charner" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Amiral Charner Class" } } }
-ship = { name = "Cassard" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "D'Assas Class" } } }
-ship = { name = "Cosmao" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Troude Class" } } }
-		}
-
-	 navy = {
-		name = "Orientale"
-		location=4401 # Saigon
-		base=4401 # Saigon
-ship = { name = "Dupleix" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = FRA } } }
-
-		}
-	 navy = {
-		name = "Groupe du Pacifique de Sud"
-		location = 12148 # Tahiti
-		base =  12148 # Tahiti
-ship = { name = "Montcalm" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = FRA version_name = "Gueydon Class" } } }
-
-		}
-	 navy = {
-		name = "Groupe des Indes de l'Ouest"
-		location = 9377 # Guadeloupe
-		base =  9377 # Guadeloupe
-ship = { name = "Descartes" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = FRA version_name = "Descartes Class" } } }
-		}
+	 
+	 
+	 
 	}
 air_wings = { 
 

--- a/mod/thegreatwar/history/units/GER_1910.txt
+++ b/mod/thegreatwar/history/units/GER_1910.txt
@@ -116,6 +116,293 @@ division_template = {
 ###################################################################
 
 units = {
+
+    fleet = {
+        name = "Hochseeflotte"
+        naval_base = 241  # Wilhelmshaven
+        task_force = {
+                name = "1. Aufklärungsschwadron"
+                location = 241  # Wilhelmshaven
+                ship = { name = "SMS Blücher" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Blücher Class" } } }
+                ship = { name = "SMS Dresden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
+                ship = { name = "SMS Königsberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+         }
+         task_force = {
+                 name = "2. Aufklärungsschwadron"
+                 location = 241  # Wilhelmshaven
+                 ship = { name = "SMS Mainz" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
+                 ship = { name = "SMS S90" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S91" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S92" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S93" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S94" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S95" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S96" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S97" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S98" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S99" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S100" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S101" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S102" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S103" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S104" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S105" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S106" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+                 ship = { name = "SMS S107" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+         }
+         task_force = {
+                name = "3. Aufklärungsschwadron"
+                location = 241  # Wilhelmshaven
+                ship = { name = "SMS München" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                ship = { name = "SMS Danzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                ship = { name = "SMS Bremen" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                ship = { name = "SMS Stuttgart" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+                ship = { name = "SMS Hela" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Hela Class" } } }
+                ship = { name = "SMS Frauenlob" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+         }
+         task_force = {
+                 name = "Küstenverteidigungsschwadron Weser"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Berlin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+                 ship = { name = "SMS Ariadne" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS Niobe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS S114" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S115" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S116" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S117" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S118" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S119" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+                 ship = { name = "SMS S120" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S121" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S122" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S123" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S124" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+                 ship = { name = "SMS S125" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+         }
+         task_force = {
+                 name = "Küstenverteidigungsschwadron Elbe"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Nymphe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS Medusa" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+                 ship = { name = "SMS Bussard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Falke" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Seeadler" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Condor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Cormoran" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Geier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS S126" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S127" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S128" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S129" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S130" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS S131" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+                 ship = { name = "SMS G132" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G133" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G134" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G135" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+                 ship = { name = "SMS G136" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+         }
+         task_force = {
+                 name = "1. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Nassau" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Westfalen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+         }
+         task_force = {
+                 name = "2. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Deutschland" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Hessen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Hannover" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Pommern" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Schlesien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Schleswig-Holstein" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+                 ship = { name = "SMS Braunschweig" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Elsaß" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Lothringen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+         }
+         task_force = {
+                 name = "4. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Wittelsbach" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Wettin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Zähringen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Schwaben" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+                 ship = { name = "SMS Mecklenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+         }
+         task_force = {
+                 name = "5. Schlachtschwadron"
+                 location = 241#Wilhelmshaven
+                 ship = { name = "SMS Wörth" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Weissenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Kaiser Friedrich III" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Wilhelm II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Wilhelm der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Karl der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kaiser Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+                 ship = { name = "SMS Kurfürst Friedrich Wilhelm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Brandenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+                 ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER } } }
+                 ship = { name = "SMS Württemberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Sachsen Class" } } }
+                 ship = { name = "SMS Oldenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Oldenburg Class" } } }
+         }
+    }
+
+fleet = {
+	name = "U-bootdivision Fleet"
+	naval_base = 6325 #Hamburg
+	task_force = {
+		name = "U-bootdivision"
+		location = 6325 #Hamburg
+		ship = { name = "SMS U1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U2 Class" } } }
+		ship = { name = "SMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
+		ship = { name = "SMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
+		ship = { name = "SMS U5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
+		ship = { name = "SMS U9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
+		ship = { name = "SMS U11" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
+	}
+}
+
+fleet = {
+	name = "Ostasienschwadron Fleet"
+	naval_base = 10000 #Qingdao
+	task_force = {
+		name = "Ostasienschwadron"
+		location = 10000 #Qingdao
+		ship = { name = "SMS Scharnhorst" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
+		ship = { name = "SMS Gneisenau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
+		ship = { name = "SMS Nürnberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+		ship = { name = "SMS Leipzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Emden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
+	}
+}
+
+fleet = {
+	name = "Küstenverteidigungsgruppe Ostsee Fleet"
+	naval_base = 321 #Rostock
+	task_force = {
+		name = "Küstenverteidigungsgruppe Ostsee"
+		location = 321 #Rostock
+		ship = { name = "SMS Friedrich Carl" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Lübeck" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Amazone" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Undine" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Arcona" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Thetis" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Gazelle" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS D1" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS D2" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS D3" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
+		ship = { name = "SMS D4" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
+		ship = { name = "SMS D5" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
+		ship = { name = "SMS D6" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
+		ship = { name = "SMS D7" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
+		ship = { name = "SMS D8" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
+		ship = { name = "SMS D9" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D9 Class" } } }
+		ship = { name = "SMS D10" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D10 Class" } } }
+	}
+	task_force = {
+		name = "5. Aufklärungsschwadron"
+		location = 321 #Rostock
+		ship = { name = "SMS Hansa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Victoria Luise" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Vineta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Hertha" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS G108" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G109" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G110" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G111" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G112" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G113" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+	}
+}
+
+fleet = {
+	name = "6. Schlachtschwadron Fleet"
+	naval_base = 11372 #Kiel
+	task_force = {
+		name = "4. Aufklärungsschwadron"
+		location = 11372 #Kiel
+		ship = { name = "SMS Roon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
+		ship = { name = "SMS Yorck" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
+		ship = { name = "SMS Prinz Heinrich" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Prinz Heinrich Class" } } }
+		ship = { name = "SMS Prinz Adalbert" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
+	}
+	task_force = {
+		name = "6. Schlachtschwadron"
+		location = 11372 #Kiel
+		ship = { name = "SMS Siegfried" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Beowulf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Frithjof" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Heimdall" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Hildebrand" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Hagen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Odin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Ägir" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS G137" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G138" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G139" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G140" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G141" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G142" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G143" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G144" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G145" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G146" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G147" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G148" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G149" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+	}
+}
+
+fleet = {
+	name = "7. Schlachtschwadron Fleet"
+	naval_base = 6332 #Konigsberg
+	task_force = {
+		name = "7. Schlachtschwadron"
+		location = 6332 #Konigsberg
+		ship = { name = "SMS Preußen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Stettin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+		ship = { name = "SMS Hamburg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Fürst Bismarck" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Fürst Bismarck Class" } } }
+		ship = { name = "SMS Freya" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Kaiserin Augusta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Irene" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
+		ship = { name = "SMS Prinzess Wilhelm" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
+		ship = { name = "SMS Gefion" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS V150" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V151" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V152" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V153" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V154" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V155" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V156" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V157" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V158" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V159" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V160" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V161" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V161 Class" } } }
+		ship = { name = "SMS V162" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
+		ship = { name = "SMS V163" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
+		ship = { name = "SMS V164" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
+		ship = { name = "SMS G169" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G170" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G171" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G172" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G173" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G174" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G175" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS S176" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
+		ship = { name = "SMS V180" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V181" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V182" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V183" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V184" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V185" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+	}
+}
+
     division = {
         name = "1. Straßenpanzerwagen"
         location = 9575
@@ -995,280 +1282,6 @@ units = {
         # start_equipment_factor = 0.3
         # start_manpower_factor = 0.3
     }
-    navy = {
-        name = "Ostasienschwadron"
-        location = 10000#Qingdao
-        base = 10000#Qingdao
-ship = { name = "SMS Scharnhorst" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
-ship = { name = "SMS Gneisenau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
-ship = { name = "SMS Nürnberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-ship = { name = "SMS Leipzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Emden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
-
-    }
-    navy = {
-        name = "Küstenverteidigungsgruppe Ostsee"
-        location = 321#Rostock
-        base = 321#Rostock
-ship = { name = "SMS Friedrich Carl" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Lübeck" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Amazone" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Undine" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Arcona" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Thetis" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Gazelle" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS D1" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS D2" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS D3" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
-ship = { name = "SMS D4" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
-ship = { name = "SMS D5" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
-ship = { name = "SMS D6" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
-ship = { name = "SMS D7" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
-ship = { name = "SMS D8" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
-ship = { name = "SMS D9" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D9 Class" } } }
-ship = { name = "SMS D10" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D10 Class" } } }
-
-    }
-    fleet = {
-        name = Hochseeflotte
-        naval_base = 241  # Wilhelmshavecn
-        task_force = {
-                name = "1. Aufklärungsschwadron"
-                location = 241  # Wilhelmshaven
-                ship = { name = "SMS Blücher" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Blücher Class" } } }
-                ship = { name = "SMS Dresden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
-                ship = { name = "SMS Königsberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-         }
-         task_force = {
-                 name = "2. Aufklärungsschwadron"
-                 location = 241  # Wilhelmshaven
-                 ship = { name = "SMS Mainz" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
-                 ship = { name = "SMS S90" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S91" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S92" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S93" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S94" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S95" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S96" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S97" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S98" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S99" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S100" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S101" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S102" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S103" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S104" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S105" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S106" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-                 ship = { name = "SMS S107" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-         }
-         task_force = {
-                name = "3. Aufklärungsschwadron"
-                location = 241  # Wilhelmshaven
-                ship = { name = "SMS München" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-                ship = { name = "SMS Danzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-                ship = { name = "SMS Bremen" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-                ship = { name = "SMS Stuttgart" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-                ship = { name = "SMS Hela" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Hela Class" } } }
-                ship = { name = "SMS Frauenlob" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-         }
-         task_force = {
-                 name = "Küstenverteidigungsschwadron Weser"
-                 location = 241#Wilhelmshaven
-                 ship = { name = "SMS Berlin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-                 ship = { name = "SMS Ariadne" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-                 ship = { name = "SMS Niobe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-                 ship = { name = "SMS S114" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-                 ship = { name = "SMS S115" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-                 ship = { name = "SMS S116" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-                 ship = { name = "SMS S117" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-                 ship = { name = "SMS S118" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-                 ship = { name = "SMS S119" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-                 ship = { name = "SMS S120" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-                 ship = { name = "SMS S121" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-                 ship = { name = "SMS S122" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-                 ship = { name = "SMS S123" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-                 ship = { name = "SMS S124" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-                 ship = { name = "SMS S125" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-         }
-         task_force = {
-                 name = "Küstenverteidigungsschwadron Elbe"
-                 location = 241#Wilhelmshaven
-                 ship = { name = "SMS Nymphe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-                 ship = { name = "SMS Medusa" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-                 ship = { name = "SMS Bussard" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Falke" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Seeadler" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Condor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Cormoran" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Geier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS S126" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-                 ship = { name = "SMS S127" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-                 ship = { name = "SMS S128" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-                 ship = { name = "SMS S129" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-                 ship = { name = "SMS S130" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-                 ship = { name = "SMS S131" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-                 ship = { name = "SMS G132" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-                 ship = { name = "SMS G133" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-                 ship = { name = "SMS G134" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-                 ship = { name = "SMS G135" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-                 ship = { name = "SMS G136" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-         }
-         task_force = {
-                 name = "1. Schlachtschwadron"
-                 location = 241#Wilhelmshaven
-                 ship = { name = "SMS Nassau" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Westfalen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-         }
-         task_force = {
-                 name = "2. Schlachtschwadron"
-                 location = 241#Wilhelmshaven
-                 ship = { name = "SMS Deutschland" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-                 ship = { name = "SMS Hessen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Hannover" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-                 ship = { name = "SMS Pommern" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-                 ship = { name = "SMS Schlesien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-                 ship = { name = "SMS Schleswig-Holstein" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-                 ship = { name = "SMS Braunschweig" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Elsaß" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Lothringen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-         }
-         task_force = {
-                 name = "4. Schlachtschwadron"
-                 location = 241#Wilhelmshaven
-                 ship = { name = "SMS Wittelsbach" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-                 ship = { name = "SMS Wettin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-                 ship = { name = "SMS Zähringen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-                 ship = { name = "SMS Schwaben" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-                 ship = { name = "SMS Mecklenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-         }
-         task_force = {
-                 name = "5. Schlachtschwadron"
-                 location = 241#Wilhelmshaven
-                 ship = { name = "SMS Wörth" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-                 ship = { name = "SMS Weissenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-                 ship = { name = "SMS Kaiser Friedrich III" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-                 ship = { name = "SMS Kaiser Wilhelm II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-                 ship = { name = "SMS Kaiser Wilhelm der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-                 ship = { name = "SMS Kaiser Karl der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-                 ship = { name = "SMS Kaiser Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-                 ship = { name = "SMS Kurfürst Friedrich Wilhelm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-                 ship = { name = "SMS Brandenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-                 ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER } } }
-                 ship = { name = "SMS Württemberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Sachsen Class" } } }
-                 ship = { name = "SMS Oldenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Oldenburg Class" } } }
-         }
-    }
-    navy = {
-        name = "4. Aufklärungsschwadron"
-        location = 11372#Kiel
-        base = 11372#Kiel
-ship = { name = "SMS Roon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
-ship = { name = "SMS Yorck" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
-ship = { name = "SMS Prinz Heinrich" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Prinz Heinrich Class" } } }
-ship = { name = "SMS Prinz Adalbert" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
-    }
-    navy = {
-        name = "5. Aufklärungsschwadron"
-        location = 321#Rostock
-        base = 321#Rostock
-ship = { name = "SMS Hansa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Victoria Luise" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Vineta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Hertha" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS G108" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G109" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G110" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G111" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G112" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G113" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "6. Schlachtschwadron"
-        location = 11372#Kiel
-        base = 11372#Kiel
-ship = { name = "SMS Siegfried" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Beowulf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Frithjof" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Heimdall" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Hildebrand" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Hagen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Odin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Ägir" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS G137" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G138" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G139" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G140" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G141" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G142" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G143" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G144" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G145" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G146" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G147" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G148" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G149" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-
-    }
-    navy = {
-        name = "7. Schlachtschwadron"
-        location = 6332#Konigsberg
-        base = 6332#Konigsberg
-ship = { name = "SMS Preußen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Stettin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-ship = { name = "SMS Hamburg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Fürst Bismarck" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Fürst Bismarck Class" } } }
-ship = { name = "SMS Freya" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Kaiserin Augusta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Irene" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
-ship = { name = "SMS Prinzess Wilhelm" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
-ship = { name = "SMS Gefion" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS V150" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V151" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V152" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V153" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V154" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V155" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V156" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V157" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V158" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V159" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V160" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V161" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V161 Class" } } }
-ship = { name = "SMS V162" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
-ship = { name = "SMS V163" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
-ship = { name = "SMS V164" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
-ship = { name = "SMS G169" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G170" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G171" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G172" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G173" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G174" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G175" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS S176" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
-ship = { name = "SMS V180" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V181" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V182" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V183" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V184" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V185" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-
-    }
-    navy = {
-        name = "U-bootdivision"
-        location = 6325#Hamburg
-        base = 6325#Hamburg
-ship = { name = "SMS U1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U2 Class" } } }
-ship = { name = "SMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
-ship = { name = "SMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
-ship = { name = "SMS U5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
-ship = { name = "SMS U9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
-ship = { name = "SMS U11" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
-
-    }
-
 }
 
 air_wings = {

--- a/mod/thegreatwar/history/units/GER_1914.txt
+++ b/mod/thegreatwar/history/units/GER_1914.txt
@@ -115,6 +115,400 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "SMS Königsberg Fleet"
+	naval_base = 2196 #Dar es Salaam
+	task_force = {
+		name = "SMS Königsberg"
+		location = 2196 #Dar es Salaam
+		ship = { name = "SMS Königsberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+	}
+}
+
+fleet = {
+	name = "Ostasienschwadron Fleet"
+	naval_base = 10000 #Qingdao
+	task_force = {
+		name = "Ostasienschwadron"
+		location = 10000 #Qingdao
+		ship = { name = "SMS Scharnhorst" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
+		ship = { name = "SMS Gneisenau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
+		ship = { name = "SMS Nürnberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+		ship = { name = "SMS Leipzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Emden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
+		ship = { name = "SMS S19" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S20" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S21" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S22" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S23" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S24" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S31" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S31' Class" } } }
+	}
+}
+
+fleet = {
+	name = "Mittelmeer-Division Fleet"
+	naval_base = 11735 #Pola
+	task_force = {
+		name = "Mittelmeer-Division"
+		location = 11735 #Pola
+		ship = { name = "SMS Goeben" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Breslau" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
+	}
+}
+
+fleet = {
+	name = "Hochseeflotte"
+	naval_base = 241 #Wilhelmshaven
+	task_force = {
+		name = "3. Cruiser schwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Danzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Stuttgart" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+		ship = { name = "SMS Seeadler" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Condor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Cormoran" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Geier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Hela" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Hela Class" } } }
+		ship = { name = "SMS Irene" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
+		ship = { name = "SMS Prinzess Wilhelm" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
+		ship = { name = "SMS Frauenlob" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+	}
+	task_force = {
+		name = "Cruiser schwadron Weser"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Berlin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Ariadne" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Niobe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS D1" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS D2" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS D3" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
+		ship = { name = "SMS D4" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
+		ship = { name = "SMS D5" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
+		ship = { name = "SMS D6" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
+	}
+	task_force = {
+		name = "Cruiser schwadron Elbe"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Nymphe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Medusa" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS D7" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
+		ship = { name = "SMS D8" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
+		ship = { name = "SMS D9" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D9 Class" } } }
+		ship = { name = "SMS D10" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D10 Class" } } }
+		ship = { name = "SMS S90" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S91" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S92" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S93" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S94" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S95" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S96" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S97" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S98" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S99" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+	}
+	task_force = {
+		name = "Flottenflaggschiff"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Friedrich der Grosse" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
+	}
+	task_force = {
+		name = "1. Schlachtschwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Nassau" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Westfalen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Rheinland" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Posen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Helgoland" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
+		ship = { name = "SMS Ostfriesland" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
+		ship = { name = "SMS Thüringen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
+		ship = { name = "SMS Oldenburg" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
+	}
+	task_force = {
+		name = "2. Schlachtschwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Deutschland" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+		ship = { name = "SMS Hessen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Hannover" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+		ship = { name = "SMS Schlesien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+		ship = { name = "SMS Schleswig-Holstein" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+		ship = { name = "SMS Braunschweig" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Elsaß" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Lothringen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Pommern" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
+	}
+	task_force = {
+		name = "3. Schlachtschwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Kaiserin" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS König Albert" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Prinzregent Luitpold" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
+	}
+	task_force = {
+		name = "4. Schlachtschwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Wittelsbach" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+		ship = { name = "SMS Wettin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+		ship = { name = "SMS Zähringen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+		ship = { name = "SMS Schwaben" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+		ship = { name = "SMS Mecklenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
+	}
+	task_force = {
+		name = "5. Schlachtschwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Kaiser Friedrich III" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+		ship = { name = "SMS Kaiser Wilhelm II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+		ship = { name = "SMS Kaiser Wilhelm der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+		ship = { name = "SMS Kaiser Karl der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+		ship = { name = "SMS Kaiser Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
+		ship = { name = "SMS Kurfürst Friedrich Wilhelm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+		ship = { name = "SMS Wörth" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
+		ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Württemberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Sachsen Class" } } }
+	}
+	task_force = {
+		name = "U-bootdivision"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS U1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U2 Class" } } }
+		ship = { name = "SMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
+		ship = { name = "SMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
+		ship = { name = "SMS U5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
+		ship = { name = "SMS U6" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
+		ship = { name = "SMS U7" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
+		ship = { name = "SMS U8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
+		ship = { name = "SMS U9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
+		ship = { name = "SMS U10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
+		ship = { name = "SMS U11" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
+		ship = { name = "SMS U12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
+		ship = { name = "SMS U13" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U14" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U15" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U16" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER version_name = "U16 Class" } } }
+		ship = { name = "SMS U17" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U18" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U19" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U20" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U21" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U22" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS U23" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
+		ship = { name = "SMS U24" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
+		ship = { name = "SMS U25" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
+		ship = { name = "SMS U26" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
+		ship = { name = "SMS U27" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
+		ship = { name = "SMS U28" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
+		ship = { name = "SMS U29" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
+		ship = { name = "SMS U30" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
+	}
+	task_force = {
+		name = "SMS Dresden"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Dresden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
+	}
+	task_force = {
+		name = "1. Cruiser schwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Von der Tann" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Moltke" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Seydlitz" definition = battle_cruiser equipment = { battle_cruiser_1914 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Blücher" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Blücher Class" } } }
+	}
+	task_force = {
+		name = "2. Crusier schwadron"
+		location = 241 #Wilhelmshaven
+		ship = { name = "SMS Strassburg" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Stralsund" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Kolberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
+		ship = { name = "SMS Mainz" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
+		ship = { name = "SMS Cöln" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
+		ship = { name = "SMS S100" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S101" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S102" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S103" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S104" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S105" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S106" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS S107" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
+		ship = { name = "SMS G108" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G109" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G110" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G111" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G112" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G113" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
+	}
+}
+
+fleet = {
+	name = "6. Schlachtschwadron Fleet"
+	naval_base = 6389 #Kiel
+	task_force = {
+		name = "6. Schlachtschwadron"
+		location = 6389 #Kiel
+		ship = { name = "SMS Siegfried" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Beowulf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Frithjof" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Heimdall" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Hildebrand" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Hagen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Odin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS Ägir" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
+		ship = { name = "SMS S114" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+		ship = { name = "SMS S115" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+		ship = { name = "SMS S116" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+		ship = { name = "SMS S117" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+		ship = { name = "SMS S118" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+		ship = { name = "SMS S119" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
+		ship = { name = "SMS S120" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+		ship = { name = "SMS S121" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+		ship = { name = "SMS S122" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+		ship = { name = "SMS S123" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+		ship = { name = "SMS S124" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+		ship = { name = "SMS S125" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
+		ship = { name = "SMS S126" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+		ship = { name = "SMS S127" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+		ship = { name = "SMS S128" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+		ship = { name = "SMS S129" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+		ship = { name = "SMS S130" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+		ship = { name = "SMS S131" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
+		ship = { name = "SMS G132" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+		ship = { name = "SMS G133" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+		ship = { name = "SMS G134" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+		ship = { name = "SMS G135" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+		ship = { name = "SMS G136" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
+	}
+	task_force = {
+		name = "4. Cruiser schwadron"
+		location = 6389 #Kiel
+		ship = { name = "SMS Roon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
+		ship = { name = "SMS Yorck" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
+		ship = { name = "SMS Prinz Heinrich" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Prinz Heinrich Class" } } }
+		ship = { name = "SMS Prinz Adalbert" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
+	}
+}
+
+fleet = {
+	name = "7. Schlachtschwadron Fleet"
+	naval_base = 6332 #Konigsberg
+	task_force = {
+		name = "7. Schlachtschwadron"
+		location = 6332 #Konigsberg
+		ship = { name = "SMS Preußen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Stettin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
+		ship = { name = "SMS Bremen" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Hamburg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Lübeck" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS München" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
+		ship = { name = "SMS Fürst Bismarck" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Fürst Bismarck Class" } } }
+		ship = { name = "SMS Freya" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Kaiserin Augusta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Gefion" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Arcona" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS G137" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS G138" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G139" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G140" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G141" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G142" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G143" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G144" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G145" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G146" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G147" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G148" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS G149" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
+		ship = { name = "SMS V150" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V151" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V152" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V153" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V154" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V155" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V156" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V157" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V158" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V159" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V160" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
+		ship = { name = "SMS V161" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V161 Class" } } }
+		ship = { name = "SMS V162" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
+		ship = { name = "SMS V163" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
+		ship = { name = "SMS V164" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
+		ship = { name = "SMS S165" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
+		ship = { name = "SMS S166" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
+		ship = { name = "SMS S167" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
+		ship = { name = "SMS S168" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
+		ship = { name = "SMS G169" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G170" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G172" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G173" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G174" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS G175" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
+		ship = { name = "SMS S176" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
+		ship = { name = "SMS S177" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
+		ship = { name = "SMS S179" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
+		ship = { name = "SMS V180" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V181" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V182" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V183" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V184" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V185" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V186" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V187" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V188" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V189" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V190" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS V191" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
+		ship = { name = "SMS G192" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
+		ship = { name = "SMS G193" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
+		ship = { name = "SMS G194" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
+		ship = { name = "SMS G195" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
+		ship = { name = "SMS G196" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
+		ship = { name = "SMS G197" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
+		ship = { name = "SMS V1" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS V2" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS V3" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS V4" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS V5" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS V6" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
+	}
+}
+
+fleet = {
+	name = "Cruiser gruppe Ostsee Fleet"
+	naval_base = 321 #Rostock
+	task_force = {
+		name = "5. Cruiser schwadron"
+		location = 321 #Rostock
+		ship = { name = "SMS Vineta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Hansa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Victoria Luise" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+		ship = { name = "SMS Hertha" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
+	}
+	task_force = {
+		name = "Cruiser gruppe Ostsee"
+		location = 321 #Rostock
+		ship = { name = "SMS Friedrich Carl" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Augsburg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
+		ship = { name = "SMS Magdeburg" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
+		ship = { name = "SMS Amazone" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Undine" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Thetis" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS Gazelle" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
+		ship = { name = "SMS G7" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
+		ship = { name = "SMS G8" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
+		ship = { name = "SMS G9" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
+		ship = { name = "SMS G10" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
+		ship = { name = "SMS G11" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
+		ship = { name = "SMS G12" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
+		ship = { name = "SMS S13" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S14" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S15" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S16" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S17" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+		ship = { name = "SMS S18" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
+	}
+}
+
     division = {
         name = "3. Infanterie-Division"
         location = 6282#Stettin
@@ -1407,406 +1801,27 @@ units = {
         # start_equipment_factor = 0.3
         # start_manpower_factor = 0.3
     }
-    navy = {
-        name = "Mittelmeer-Division"
-        location = 11735#Pola
-        base = 11735#Pola
-ship = { name = "SMS Goeben" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Breslau" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "3. Cruiser schwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Danzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Stuttgart" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-ship = { name = "SMS Seeadler" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Condor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Cormoran" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Geier" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Hela" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Hela Class" } } }
-ship = { name = "SMS Irene" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
-ship = { name = "SMS Prinzess Wilhelm" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GER version_name = "Irene Class" } } }
-ship = { name = "SMS Frauenlob" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-
-    }
-    navy = {
-        name = "Cruiser schwadron Weser"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Berlin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Ariadne" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Niobe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS D1" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS D2" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS D3" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
-ship = { name = "SMS D4" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D3 Class" } } }
-ship = { name = "SMS D5" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
-ship = { name = "SMS D6" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D5 Class" } } }
-
-    }
-    navy = {
-        name = "Cruiser schwadron Elbe"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Nymphe" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Medusa" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS D7" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
-ship = { name = "SMS D8" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D7 Class" } } }
-ship = { name = "SMS D9" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D9 Class" } } }
-ship = { name = "SMS D10" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "D10 Class" } } }
-ship = { name = "SMS S90" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S91" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S92" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S93" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S94" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S95" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S96" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S97" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S98" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S99" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-
-    }
-    navy = {
-        name = "Flottenflaggschiff"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Friedrich der Grosse" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "1. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Nassau" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Westfalen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Rheinland" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Posen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Helgoland" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
-ship = { name = "SMS Ostfriesland" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
-ship = { name = "SMS Thüringen" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
-ship = { name = "SMS Oldenburg" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = GER version_name = "Helgoland Class" } } }
-
-    }
-    navy = {
-        name = "2. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Deutschland" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Hessen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Hannover" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Schlesien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Schleswig-Holstein" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-ship = { name = "SMS Braunschweig" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Elsaß" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Lothringen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Pommern" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER version_name = "Deutschland Class" } } }
-
-    }
-    navy = {
-        name = "3. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Kaiserin" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS König Albert" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Prinzregent Luitpold" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "4. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Wittelsbach" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Wettin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Zähringen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Schwaben" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-ship = { name = "SMS Mecklenburg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Wittelsbach Class" } } }
-
-    }
-    navy = {
-        name = "5. Schlachtschwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Kaiser Friedrich III" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Wilhelm II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Wilhelm der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Karl der Große" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kaiser Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Kaiser Friedrich III Class" } } }
-ship = { name = "SMS Kurfürst Friedrich Wilhelm" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-ship = { name = "SMS Wörth" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Brandenburg Class" } } }
-ship = { name = "SMS Kaiser" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Württemberg" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Sachsen Class" } } }
-
-    }
-    navy = {
-        name = "U-bootdivision"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS U1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U2 Class" } } }
-ship = { name = "SMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
-ship = { name = "SMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U3 Class" } } }
-ship = { name = "SMS U5" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
-ship = { name = "SMS U6" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
-ship = { name = "SMS U7" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
-ship = { name = "SMS U8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U5 Class" } } }
-ship = { name = "SMS U9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
-ship = { name = "SMS U10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
-ship = { name = "SMS U11" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
-ship = { name = "SMS U12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = GER version_name = "U9 Class" } } }
-ship = { name = "SMS U13" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U14" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U15" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U16" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GER version_name = "U16 Class" } } }
-ship = { name = "SMS U17" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U18" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U19" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U20" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U21" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U22" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS U23" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
-ship = { name = "SMS U24" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
-ship = { name = "SMS U25" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
-ship = { name = "SMS U26" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U23 Class" } } }
-ship = { name = "SMS U27" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
-ship = { name = "SMS U28" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
-ship = { name = "SMS U29" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
-ship = { name = "SMS U30" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = GER version_name = "U27 Class" } } }
-
-    }
-    navy = {
-        name = "SMS Dresden"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Dresden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
-
-    }
-    navy = {
-        name = "1. Cruiser schwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Von der Tann" definition = battle_cruiser equipment = { battle_cruiser_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Moltke" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Seydlitz" definition = battle_cruiser equipment = { battle_cruiser_1914 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Blücher" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Blücher Class" } } }
-
-    }
-    navy = {
-        name = "2. Crusier schwadron"
-        location = 241#Wilhelmshaven
-        base = 241#Wilhelmshaven
-ship = { name = "SMS Strassburg" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Stralsund" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Kolberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
-ship = { name = "SMS Mainz" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
-ship = { name = "SMS Cöln" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
-ship = { name = "SMS S100" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S101" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S102" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S103" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S104" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S105" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S106" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS S107" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = GER version_name = "S90 Class" } } }
-ship = { name = "SMS G108" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G109" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G110" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G111" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G112" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G113" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "6. Schlachtschwadron"
-        location = 6389#Kiel
-        base = 6389#Kiel
-ship = { name = "SMS Siegfried" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Beowulf" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Frithjof" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Heimdall" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Hildebrand" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Hagen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Odin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS Ägir" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = GER version_name = "Siegfried Class" } } }
-ship = { name = "SMS S114" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S115" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S116" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S117" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S118" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S119" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S114 Class" } } }
-ship = { name = "SMS S120" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S121" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S122" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S123" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S124" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S125" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S120 Class" } } }
-ship = { name = "SMS S126" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S127" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S128" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S129" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S130" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS S131" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "S126 Class" } } }
-ship = { name = "SMS G132" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G133" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G134" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G135" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-ship = { name = "SMS G136" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GER version_name = "G132 Class" } } }
-
-    }
-    navy = {
-        name = "7. Schlachtschwadron"
-        location = 6332#Konigsberg
-        base = 6332#Konigsberg
-ship = { name = "SMS Preußen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Stettin" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-ship = { name = "SMS Bremen" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Hamburg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Lübeck" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS München" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Fürst Bismarck" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Fürst Bismarck Class" } } }
-ship = { name = "SMS Freya" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Kaiserin Augusta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Gefion" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Arcona" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS G137" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER } } }
-ship = { name = "SMS G138" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G139" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G140" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G141" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G142" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G143" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G144" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G145" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G146" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G147" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G148" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS G149" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S138 Class" } } }
-ship = { name = "SMS V150" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V151" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V152" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V153" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V154" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V155" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V156" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V157" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V158" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V159" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V160" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V150 Class" } } }
-ship = { name = "SMS V161" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V161 Class" } } }
-ship = { name = "SMS V162" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
-ship = { name = "SMS V163" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
-ship = { name = "SMS V164" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V162 Class" } } }
-ship = { name = "SMS S165" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
-ship = { name = "SMS S166" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
-ship = { name = "SMS S167" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
-ship = { name = "SMS S168" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S165 Class" } } }
-ship = { name = "SMS G169" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G170" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G172" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G173" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G174" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS G175" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G169 Class" } } }
-ship = { name = "SMS S176" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
-ship = { name = "SMS S177" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
-ship = { name = "SMS S179" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "S176 Class" } } }
-ship = { name = "SMS V180" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V181" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V182" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V183" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V184" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V185" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V186" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V187" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V188" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V189" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V190" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS V191" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "V180 Class" } } }
-ship = { name = "SMS G192" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
-ship = { name = "SMS G193" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
-ship = { name = "SMS G194" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
-ship = { name = "SMS G195" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
-ship = { name = "SMS G196" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
-ship = { name = "SMS G197" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GER version_name = "G192 Class" } } }
-ship = { name = "SMS V1" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS V2" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS V3" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS V4" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS V5" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS V6" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "4. Cruiser sschwadron"
-        location = 6389#Kiel
-        base = 6389#Kiel
-ship = { name = "SMS Roon" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
-ship = { name = "SMS Yorck" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Roon Class" } } }
-ship = { name = "SMS Prinz Heinrich" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Prinz Heinrich Class" } } }
-ship = { name = "SMS Prinz Adalbert" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
-
-    }
-    navy = {
-        name = "5. Cruiser schwadron"
-        location = 321#Rostock
-        base = 321#Rostock
-ship = { name = "SMS Vineta" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Hansa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Victoria Luise" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-ship = { name = "SMS Hertha" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GER version_name = "Victoria Luise Class" } } }
-
-    }
-    navy = {
-        name = "Cruiser gruppe Ostsee"
-        location = 321#Rostock
-        base = 321#Rostock
-ship = { name = "SMS Friedrich Carl" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Augsburg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Kolberg Class" } } }
-ship = { name = "SMS Magdeburg" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = GER } } }
-ship = { name = "SMS Amazone" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Undine" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Thetis" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS Gazelle" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Gazelle Class" } } }
-ship = { name = "SMS G7" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
-ship = { name = "SMS G8" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
-ship = { name = "SMS G9" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
-ship = { name = "SMS G10" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
-ship = { name = "SMS G11" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
-ship = { name = "SMS G12" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "G7 Class" } } }
-ship = { name = "SMS S13" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S14" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S15" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S16" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S17" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S18" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-
-    }
-    navy = {
-        name = "SMS Königsberg"
-        location = 2196#Dar es Salaam
-        base = 2196#Dar es Salaam
-ship = { name = "SMS Königsberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-
-    }
-    navy = {
-        name = "Ostasienschwadron"
-        location = 10000#Qingdao
-        base = 10000#Qingdao
-ship = { name = "SMS Scharnhorst" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
-ship = { name = "SMS Gneisenau" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = GER version_name = "Scharnhorst Class" } } }
-ship = { name = "SMS Nürnberg" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Königsberg Class" } } }
-ship = { name = "SMS Leipzig" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Bremen Class" } } }
-ship = { name = "SMS Emden" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = GER version_name = "Dresden Class" } } }
-ship = { name = "SMS S19" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S20" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S21" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S22" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S23" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S24" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S13 Class" } } }
-ship = { name = "SMS S31" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GER version_name = "S31' Class" } } }
-
-    }
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
 }
 air_wings = {
     55 = {

--- a/mod/thegreatwar/history/units/GRE_1910.txt
+++ b/mod/thegreatwar/history/units/GRE_1910.txt
@@ -39,6 +39,30 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Basilikos Stolos Ellenas Fleet"
+	naval_base = 4109 # Athina
+	task_force = {
+		name = "Basilikos Stolos Ellenas"
+		location = 4109 # Athina
+		ship = { name = "EBN Baseleos Georgios" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Basilissa Olga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Basilissa Olga Class" } } }
+		ship = { name = "EBN Hydra" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
+		ship = { name = "EBN Spetsai" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
+		ship = { name = "EBN Psara" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
+		ship = { name = "EBN Navarchos Miaoulis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Niki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Doxa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Aspis" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Velos" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Thyella" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Nafkratousa" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Lonchi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Sfendoni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+	}
+}
+
 	division= { 
 		name = "I Merarchia"
 		location = 4109 # Athina
@@ -173,26 +197,7 @@ units = {
 		start_experience_factor=0.05
 	}
 
- 	navy = {
-		name = "Basilikos Stolos Ellenas"
-		location = 4109 # Athina
-		base =  4109 # Athina
-		
-		ship = { name = "EBN Baseleos Georgios" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Basilissa Olga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Basilissa Olga Class" } } }
-		ship = { name = "EBN Hydra" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
-		ship = { name = "EBN Spetsai" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
-		ship = { name = "EBN Psara" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
-		ship = { name = "EBN Navarchos Miaoulis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Niki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Doxa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Aspis" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Velos" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Thyella" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Nafkratousa" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Lonchi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-		ship = { name = "EBN Sfendoni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-	}
+ 	
 }
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/GRE_1914.txt
+++ b/mod/thegreatwar/history/units/GRE_1914.txt
@@ -39,6 +39,36 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Basilikos Stolos Ellenas Fleet"
+	naval_base = 4109 # Athina
+	task_force = {
+		name = "Basilikos Stolos Ellenas"
+		location = 4109 # Athina
+		ship = { name = "EBN Basilissa Olga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Basilissa Olga Class" } } }
+		ship = { name = "EBN Hydra" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
+		ship = { name = "EBN Spetsai" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
+		ship = { name = "EBN Psara" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
+		ship = { name = "EBN Georgios Averof" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Pisa Class" } } }
+		ship = { name = "EBN Navarchos Miaoulis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Niki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Doxa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Aspis" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Velos" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Thyella" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Nafkratousa" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Lonchi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Sfendoni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Aetos" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Ierax" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Panthir" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Leon" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Delfin" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GRE } } }
+		ship = { name = "EBN Xifias" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GRE } } }
+	}
+}
+
 	division= { 
 			name = "I Merarchia"
 			location = 4109 # Athina
@@ -165,33 +195,7 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Basilikos Stolos Ellenas"
-		location = 4109 # Athina
-		base =  4109 # Athina
-ship = { name = "EBN Basilissa Olga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Basilissa Olga Class" } } }
-ship = { name = "EBN Hydra" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
-ship = { name = "EBN Spetsai" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
-ship = { name = "EBN Psara" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Hydra Class" } } }
-ship = { name = "EBN Georgios Averof" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = GRE version_name = "Pisa Class" } } }
-ship = { name = "EBN Navarchos Miaoulis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Niki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Doxa" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Aspis" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Velos" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Thyella" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Nafkratousa" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Lonchi" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Sfendoni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Aetos" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Ierax" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Panthir" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Leon" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Delfin" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GRE } } }
-ship = { name = "EBN Xifias" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = GRE } } }
-
- 
-		}
+	 
 	}
 air_wings = { 
 	

--- a/mod/thegreatwar/history/units/HOL_1910.txt
+++ b/mod/thegreatwar/history/units/HOL_1910.txt
@@ -33,6 +33,50 @@ division_template = {
 
 
 units = {
+
+fleet = {
+	name = "West-Indië Vloot Fleet"
+	naval_base = 9498 # Curaçao
+	task_force = {
+		name = "West-Indië Vloot"
+		location = 9498 # Curaçao
+		ship = { name = "HrMs Jacob Van Heemskerck" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Friesland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs Gelderland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+	}
+}
+
+fleet = {
+	name = "Koninklijke Marine Fleet"
+	naval_base = 9498 # Amsterdam
+	task_force = {
+		name = "Koninklijke Marine"
+		location = 9498 # Amsterdam
+		ship = { name = "HrMs Reinier Claeszen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Evertsen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
+		ship = { name = "HrMs Piet Hein" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
+		ship = { name = "HrMs De Ruyter" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Martin Harpertszoon Tromp" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Holland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs Zeeland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs Noord-Brabant" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs Utrecht" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs O1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = HOL } } }
+	}
+}
+
+fleet = {
+	name = "Oost-Indië Vloot Fleet"
+	naval_base = 4608 # Soerabaja
+	task_force = {
+		name = "Oost-Indië Vloot"
+		location = 4608 # Soerabaja
+		ship = { name = "HrMs Koningin Regentes" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Kortenaer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
+		ship = { name = "HrMs Hertog Hendrik" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+	}
+}
+
 	division= { 
 			name = "1e Divisie"
 			location=391 # Amsterdam
@@ -83,41 +127,9 @@ units = {
 			# start_equipment_factor = 0.3 
 			# start_manpower_factor = 0.3
 			}
-	 navy = {
-		name = "Koninklijke Marine"
-		location=9498 # Amsterdam
-		base=9498 # Amsterdam
-		
-		
-ship = { name = "HrMs Reinier Claeszen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Evertsen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
-ship = { name = "HrMs Piet Hein" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
-ship = { name = "HrMs De Ruyter" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Martin Harpertszoon Tromp" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Holland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs Zeeland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs Noord-Brabant" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs Utrecht" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs O1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = HOL } } }
-		}
-	 navy = {
-		name = "Oost-Indië Vloot"
-		location=4608 # Soerabaja
-		base=4608 # Soerabaja
-
-ship = { name = "HrMs Koningin Regentes" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Kortenaer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
-ship = { name = "HrMs Hertog Hendrik" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-		}
-	 navy = {
-		name = "West-Indië Vloot"
-		location = 9498 # Curaçao
-		base =  9498 # Curaçao
-
-ship = { name = "HrMs Jacob Van Heemskerck" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Friesland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs Gelderland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-		}
+	 
+	 
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/HOL_1914.txt
+++ b/mod/thegreatwar/history/units/HOL_1914.txt
@@ -34,6 +34,61 @@ division_template = {
 
 
 units = {
+
+fleet = {
+	name = "Koninklijke Marine Fleet"
+	naval_base = 9498 # Amsterdam
+	task_force = {
+		name = "Koninklijke Marine"
+		location = 9498 # Amsterdam
+		ship = { name = "HrMs Reinier Claeszen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Piet Hein" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
+		ship = { name = "HrMs Kortenaer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
+		ship = { name = "HrMs Martin Harpertszoon Tromp" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs De Zeven Provincien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL version_name = "De Zeven Provincien Class" } } }
+		ship = { name = "HrMs Holland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs Zeeland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs Noord-Brabant" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs O1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs O2" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs O3" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs O4" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs O5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs K1" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = HOL } } }
+	}
+}
+
+fleet = {
+	name = "Oost-Indië Vloot Fleet"
+	naval_base = 4608 # Soerabaja
+	task_force = {
+		name = "Oost-Indië Vloot"
+		location = 4608 # Soerabaja
+		ship = { name = "HrMs Koningin Regentes" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs De Ruyter" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Hertog Hendrik" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Bulhound" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Fret" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Jakhals" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Wolf" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Hermelijn" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Lynx" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Panther" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+		ship = { name = "HrMs Vos" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
+	}
+}
+
+fleet = {
+	name = "West-Indië Vloot Fleet"
+	naval_base = 9498 # Curaçao
+	task_force = {
+		name = "West-Indië Vloot"
+		location = 9498 # Curaçao
+		ship = { name = "HrMs Gelderland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
+		ship = { name = "HrMs Jacob Van Heemskerck" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
+	}
+}
+
 	division= { 
 			name = "1e Divisie"
 			location=391 # Amsterdam
@@ -84,50 +139,9 @@ units = {
 			# start_equipment_factor = 0.3 
 			# start_manpower_factor = 0.3
 			}
-	 navy = {
-		name = "Koninklijke Marine"
-		location=9498 # Amsterdam
-		base=9498 # Amsterdam
-ship = { name = "HrMs Reinier Claeszen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Piet Hein" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
-ship = { name = "HrMs Kortenaer" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = HOL version_name = "Evertsen Class" } } }
-ship = { name = "HrMs Martin Harpertszoon Tromp" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs De Zeven Provincien" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL version_name = "De Zeven Provincien Class" } } }
-ship = { name = "HrMs Holland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs Zeeland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs Noord-Brabant" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs O1" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs O2" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs O3" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs O4" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs O5" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs K1" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = HOL } } }
-
-		}
-	 navy = {
-		name = "Oost-Indië Vloot"
-		location=4608 # Soerabaja
-		base=4608 # Soerabaja
-ship = { name = "HrMs Koningin Regentes" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs De Ruyter" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Hertog Hendrik" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Bulhound" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Fret" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Jakhals" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Wolf" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Hermelijn" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Lynx" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Panther" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-ship = { name = "HrMs Vos" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = HOL } } }
-		}
-	 navy = {
-		name = "West-Indië Vloot"
-		location = 9498 # Curaçao
-		base =  9498 # Curaçao
-
-ship = { name = "HrMs Gelderland" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = HOL version_name = "Holland Class" } } }
-ship = { name = "HrMs Jacob Van Heemskerck" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = HOL } } }
-		}
+	 
+	 
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/ITA_1910.txt
+++ b/mod/thegreatwar/history/units/ITA_1910.txt
@@ -95,6 +95,147 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "1a Squadra Navale Fleet"
+	naval_base = 11837 # Taranto
+	task_force = {
+		name = "1a Squadra Navale"
+		location = 11837 # Taranto
+		ship = { name = "RN Napoli" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Regina Elena" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Roma" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Vittorio Emanuele" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Pisa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
+		ship = { name = "RN Amalfi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
+		ship = { name = "RN Tripoli" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Goito" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
+		ship = { name = "RN Montebello" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
+		ship = { name = "RN Aretusa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Caprera" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Euridice" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Iride" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Partenope" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Urania" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Agortdat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Giovanni Bausan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Bausan Class" } } }
+	}
+	task_force = {
+		name = "2a Squadra Navale"
+		location = 11837 # Taranto
+		ship = { name = "RN Ammiraglio di Saint Bon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
+		ship = { name = "RN Emanuele Filiberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
+		ship = { name = "RN Benedetto Brin" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Regina Margherita" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Giuseppe Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
+		ship = { name = "RN Varese" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
+		ship = { name = "RN Francesco Ferruccio" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
+		ship = { name = "RN Marco Polo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Coatit" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
+	}
+	task_force = {
+		name = "Divisione Navi Scuola"
+		location = 11837 # Taranto
+		ship = { name = "RN Re Umberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
+		ship = { name = "RN Sardegna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
+		ship = { name = "RN Sicilia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
+		ship = { name = "RN Carlo Alberto" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
+	}
+	task_force = {
+		name = "1a Squadra Sommergibili"
+		location = 11837 # Taranto
+		ship = { name = "RN Delfino" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Glauco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Narvalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Otaria" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Squalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Tricheco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Foca" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ITA } } }
+	}
+	task_force = {
+		name = "RN Calabria"
+		location = 11837 # Taranto
+		ship = { name = "RN Calabria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Calabria Class" } } }
+	}
+	task_force = {
+		name = "RN Etruria"
+		location = 11837 # Taranto
+		ship = { name = "RN Etruria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+	}
+}
+
+fleet = {
+	name = "Divisione Torpediniere Fleet"
+	naval_base = 925 # Venezia
+	task_force = {
+		name = "Divisione Torpediniere"
+		location = 925 # Venezia
+		ship = { name = "RN Vittor Pisani" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
+		ship = { name = "RN Fulmine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Lampo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Freccia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Dardo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Strale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Euro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Ostro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Nembo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Turbine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Aquilone" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Borea" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Zeffiro" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Espero" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+	}
+}
+
+fleet = {
+	name = "1o Gruppo di Riserva Fleet"
+	naval_base = 925 # La Spezia
+	task_force = {
+		name = "1o Gruppo di Riserva"
+		location = 925 # La Spezia
+		ship = { name = "RN Artigliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Bersagliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Corazziere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Garibaldino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Granatiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Lanciere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Alpino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Caribiniere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Fuciliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Pontiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+	}
+}
+
+fleet = {
+	name = "Squadra del Mar Rosso Fleet"
+	naval_base = 925 # Edd
+	task_force = {
+		name = "Squadra del Mar Rosso"
+		location = 925 # Edd
+		ship = { name = "RN Elba" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Puglia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Etna" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Etna Class" } } }
+		ship = { name = "RN Stromboli" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Etna Class" } } }
+		ship = { name = "RN Piemonte" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Piemonte Class" } } }
+		ship = { name = "RN Liguria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Lombardia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+	}
+}
+
+fleet = {
+	name = "5a Divisione Navale Fleet"
+	naval_base = 10074 # Palermo
+	task_force = {
+		name = "5a Divisione Navale"
+		location = 10074 # Palermo
+		ship = { name = "RN Dandalo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Italia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
+		ship = { name = "RN Lepanto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
+		ship = { name = "RN Ruggiero di Lauria" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ruggiero di Lauria Class" } } }
+	}
+}
+
 	division= { 
 			name = "1a Brigada Alpini"
 			location = 9904 # Roma
@@ -533,139 +674,16 @@ units = {
 			division_template="Coloniali Troops"
 			start_experience_factor=0.05
 			}
-	navy = {
-		name = "1a Squadra Navale"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Napoli" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Regina Elena" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Roma" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Vittorio Emanuele" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Pisa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
-ship = { name = "RN Amalfi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
-ship = { name = "RN Tripoli" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Goito" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
-ship = { name = "RN Montebello" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
-ship = { name = "RN Aretusa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Caprera" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Euridice" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Iride" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Partenope" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Urania" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Agortdat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Giovanni Bausan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Bausan Class" } } }
-
-	}
-	navy = {
-		name = "2a Squadra Navale"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Ammiraglio di Saint Bon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
-ship = { name = "RN Emanuele Filiberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
-ship = { name = "RN Benedetto Brin" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Regina Margherita" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Giuseppe Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
-ship = { name = "RN Varese" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
-ship = { name = "RN Francesco Ferruccio" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
-ship = { name = "RN Marco Polo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Coatit" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
-
-	}
-	navy = {
-		name = "Divisione Torpediniere"
-		location = 11584 # Venezia
-		base =  925 # Venezia
-ship = { name = "RN Vittor Pisani" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
-ship = { name = "RN Fulmine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Lampo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Freccia" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Dardo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Strale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Euro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Ostro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Nembo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Turbine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Aquilone" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Borea" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Zeffiro" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Espero" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-
-	}
-	navy = {
-		name = "1o Gruppo di Riserva"
-		location = 6973 # La Spezia
-		base =  925 # La Spezia
-ship = { name = "RN Artigliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Bersagliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Corazziere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Garibaldino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Granatiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Lanciere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Alpino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Caribiniere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Fuciliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Pontiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-
-	}
-	navy = {
-		name = "Divisione Navi Scuola"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Re Umberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
-ship = { name = "RN Sardegna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
-ship = { name = "RN Sicilia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
-ship = { name = "RN Carlo Alberto" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
-	}
-	navy = {
-		name = "1a Squadra Sommergibili"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Delfino" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Glauco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Narvalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Otaria" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Squalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Tricheco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Foca" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ITA } } }
-
-	}
-	navy = {
-		name = "Squadra del Mar Rosso"
-		location = 12766 # Edd
-		base =  925 # Edd
-ship = { name = "RN Elba" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Puglia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Etna" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Etna Class" } } }
-ship = { name = "RN Stromboli" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Etna Class" } } }
-ship = { name = "RN Piemonte" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Piemonte Class" } } }
-ship = { name = "RN Liguria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Lombardia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-	}
-	navy = {
-		name = "5a Divisione Navale"
-		location=10074 # Palermo
-		base=10074 # Palermo
-ship = { name = "RN Dandalo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Italia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
-ship = { name = "RN Lepanto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
-ship = { name = "RN Ruggiero di Lauria" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ruggiero di Lauria Class" } } }
-
-	}
-	navy = {
-		name = "RN Calabria"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Calabria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Calabria Class" } } }
-
-	}
-	navy = {
-		name = "RN Etruria"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Etruria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-
-	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
 }
 air_wings = { 
 	115 = {

--- a/mod/thegreatwar/history/units/ITA_1914.txt
+++ b/mod/thegreatwar/history/units/ITA_1914.txt
@@ -95,6 +95,149 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Dipartimento di Venezia Fleet"
+	naval_base = 11584 # Venezia
+	task_force = {
+		name = "Dipartimento di Venezia"
+		location = 11584 # Venezia
+		ship = { name = "RN Dandalo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Re Umberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
+		ship = { name = "RN Sardegna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
+		ship = { name = "RN Sicilia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
+		ship = { name = "RN Italia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
+		ship = { name = "RN Lepanto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
+		ship = { name = "RN Ammiraglio di Saint Bon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
+		ship = { name = "RN Emanuele Filiberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
+		ship = { name = "RN Marco Polo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Carlo Alberto" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
+		ship = { name = "RN Elba" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Etruria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Lombardia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Foca" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Argo" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Fisalia" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Jalea" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Jantina" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Medusa" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Salpa" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Valella" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Zoea" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Atropo" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Atropo Class" } } }
+		ship = { name = "RN Nautilus" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Nautilus Class" } } }
+		ship = { name = "RN Nereide" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Nautilus Class" } } }
+		ship = { name = "RN Galileo Ferraris" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Pullino Class" } } }
+		ship = { name = "RN Giacinto Pullino" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Pullino Class" } } }
+	}
+}
+
+fleet = {
+	name = "Squadra di Tripoli Fleet"
+	naval_base = 1149 # Tripoli
+	task_force = {
+		name = "Squadra di Tripoli"
+		location = 1149 # Tripoli
+		ship = { name = "RN Liguria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Giovanni Bausan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Bausan Class" } } }
+		ship = { name = "RN Etna" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Etna Class" } } }
+		ship = { name = "RN Nembo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Turbine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Aquilone" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Borea" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Zeffiro" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Espero" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
+	}
+}
+
+fleet = {
+	name = "Squadra Eritrea Fleet"
+	naval_base = 12766 # Edd
+	task_force = {
+		name = "Squadra Eritrea"
+		location = 12766 # Edd
+		ship = { name = "RN Calabria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Calabria Class" } } }
+	}
+}
+
+fleet = {
+	name = "1a Squadra Navale Fleet"
+	naval_base = 11837 # Taranto
+	task_force = {
+		name = "1a Squadra Navale"
+		location = 11837 # Taranto
+		ship = { name = "RN Dante Alighieri" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Napoli" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Regina Elena" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Roma" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Vittorio Emanuele" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
+		ship = { name = "RN Pisa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
+		ship = { name = "RN Amalfi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
+		ship = { name = "RN San Giorgio" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "San Giorgio Class" } } }
+		ship = { name = "RN San Marco" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "San Giorgio Class" } } }
+		ship = { name = "RN Artigliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Bersagliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Corazziere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Garibaldino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Granatiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Lanciere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Alpino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Caribiniere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Fuciliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Pontiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
+		ship = { name = "RN Ascaro" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Ascaro Class" } } }
+		ship = { name = "RN Indomito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Impavido" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Impetuoso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Insidioso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Intrepido" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Irrequieto" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Ardito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA version_name = "Ardito Class" } } }
+		ship = { name = "RN Ardente" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA version_name = "Ardito Class" } } }
+		ship = { name = "RN Audace" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Animoso" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ITA } } }
+	}
+	task_force = {
+		name = "2a Squadra Navale"
+		location = 11837 # Taranto
+		ship = { name = "RN Benedetto Brin" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Regina Margherita" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Vittor Pisani" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
+		ship = { name = "RN Francesco Ferruccio" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
+		ship = { name = "RN Giuseppe Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
+		ship = { name = "RN Varese" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
+		ship = { name = "RN Piemonte" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Piemonte Class" } } }
+		ship = { name = "RN Quarto" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Agortdat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Tripoli" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Goito" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
+		ship = { name = "RN Montebello" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
+		ship = { name = "RN Euridice" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Iride" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Partenope" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
+		ship = { name = "RN Libia" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Puglia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
+		ship = { name = "RN Delfino" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Glauco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Narvalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Otaria" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Squalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+		ship = { name = "RN Tricheco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
+	}
+	task_force = {
+		name = "Dipartimento di Taranto"
+		location = 11837 # Taranto
+		ship = { name = "RN Coatit" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Fulmine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA } } }
+		ship = { name = "RN Lampo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Dardo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Strale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Euro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+		ship = { name = "RN Ostro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
+	}
+}
+
 	division= { 
 			name = "1a Reggimento Alpini"
 			location = 9904 # Roma
@@ -668,141 +811,12 @@ units = {
 			start_experience_factor=0.05
 			}
 			
-	 navy = {
-		name = "1a Squadra Navale"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Dante Alighieri" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Napoli" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Regina Elena" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Roma" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Vittorio Emanuele" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA version_name = "Regina Elena Class" } } }
-ship = { name = "RN Pisa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
-ship = { name = "RN Amalfi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Pisa Class" } } }
-ship = { name = "RN San Giorgio" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "San Giorgio Class" } } }
-ship = { name = "RN San Marco" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "San Giorgio Class" } } }
-ship = { name = "RN Artigliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Bersagliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Corazziere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Garibaldino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Granatiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Lanciere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Alpino" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Caribiniere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Fuciliere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Pontiere" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Soldati Class" } } }
-ship = { name = "RN Ascaro" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA version_name = "Ascaro Class" } } }
-ship = { name = "RN Indomito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Impavido" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Impetuoso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Insidioso" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Intrepido" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Irrequieto" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Ardito" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA version_name = "Ardito Class" } } }
-ship = { name = "RN Ardente" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = ITA version_name = "Ardito Class" } } }
-ship = { name = "RN Audace" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Animoso" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = ITA } } }
-
-		}
-	 navy = {
-		name = "2a Squadra Navale"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Benedetto Brin" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Regina Margherita" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Vittor Pisani" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
-ship = { name = "RN Francesco Ferruccio" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
-ship = { name = "RN Giuseppe Garibaldi" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
-ship = { name = "RN Varese" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Garibaldi Class" } } }
-ship = { name = "RN Piemonte" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Piemonte Class" } } }
-ship = { name = "RN Quarto" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Agortdat" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Tripoli" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Goito" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
-ship = { name = "RN Montebello" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Goito Class" } } }
-ship = { name = "RN Euridice" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Iride" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Minerva" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Partenope" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ITA version_name = "Partenope Class" } } }
-ship = { name = "RN Libia" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Puglia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Delfino" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Glauco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Narvalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Otaria" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Squalo" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-ship = { name = "RN Tricheco" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = ITA version_name = "Glauco Class" } } }
-
-		}
-	 navy = {
-		name = "Dipartimento di Venezia"
-		location = 11584 # Venezia
-		base =  11584 # Venezia
-ship = { name = "RN Dandalo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Re Umberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
-ship = { name = "RN Sardegna" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
-ship = { name = "RN Sicilia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Re Umberto Class" } } }
-ship = { name = "RN Italia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
-ship = { name = "RN Lepanto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Italia Class" } } }
-ship = { name = "RN Ammiraglio di Saint Bon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
-ship = { name = "RN Emanuele Filiberto" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = ITA version_name = "Ammiraglio di Saint Bon Class" } } }
-ship = { name = "RN Marco Polo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Carlo Alberto" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = ITA version_name = "Vittor Pisani Class" } } }
-ship = { name = "RN Elba" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Etruria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Lombardia" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Foca" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Argo" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Fisalia" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Jalea" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Jantina" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Medusa" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Salpa" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Valella" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Zoea" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Atropo" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Atropo Class" } } }
-ship = { name = "RN Nautilus" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Nautilus Class" } } }
-ship = { name = "RN Nereide" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Nautilus Class" } } }
-ship = { name = "RN Galileo Ferraris" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Pullino Class" } } }
-ship = { name = "RN Giacinto Pullino" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = ITA version_name = "Pullino Class" } } }
-
-		}
-	 navy = {
-		name = "Dipartimento di Taranto"
-		location=11837 # Taranto
-		base=11837 # Taranto
-ship = { name = "RN Coatit" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Fulmine" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Lampo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Dardo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Strale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Euro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-ship = { name = "RN Ostro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = ITA version_name = "Lampo Class" } } }
-
-
-		}
-	 navy = {
-		name = "Squadra di Tripoli"
-		location=1149 # Tripoli
-		base=1149 # Tripoli
-ship = { name = "RN Liguria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Umbria Class" } } }
-ship = { name = "RN Giovanni Bausan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Bausan Class" } } }
-ship = { name = "RN Etna" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Etna Class" } } }
-ship = { name = "RN Nembo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Turbine" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Aquilone" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Borea" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Zeffiro" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-ship = { name = "RN Espero" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = ITA } } }
-
-		}
-	 navy = {
-		name = "Squadra Eritrea"
-		location = 12766 # Edd
-		base =  12766 # Edd
-ship = { name = "RN Calabria" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ITA version_name = "Calabria Class" } } }
-
-		}
+	 
+	 
+	 
+	 
+	 
+	 
 	}
 
 air_wings = { 

--- a/mod/thegreatwar/history/units/JAP_1910.txt
+++ b/mod/thegreatwar/history/units/JAP_1910.txt
@@ -39,6 +39,159 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "5 Sentai Fleet"
+	naval_base = 9859 # Tokyo
+	task_force = {
+		name = "1 Sentai"
+		location = 9859 # Tokyo
+		ship = { name = "IJN Sagami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
+		ship = { name = "IJN Katori" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
+		ship = { name = "IJN Iki" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Imperator Alexander II Class" } } }
+		ship = { name = "IJN Kasuga" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Nisshin" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Tsushima" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Akebono" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Ikazuchi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Oboro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Sazanami" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Murakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Kagero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Shinonome" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Shiranui" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Usugumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Yugiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Kasumi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Akatsuki Class" } } }
+	}
+	task_force = {
+		name = "2 Sentai"
+		location = 9859 # Tokyo
+		ship = { name = "IJN Iwami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Suwo" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
+		ship = { name = "IJN Aso" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Bayan Class" } } }
+		ship = { name = "IJN Tsukuba" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
+		ship = { name = "IJN Niitaka" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Chitose" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
+		ship = { name = "IJN Kasagi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
+		ship = { name = "IJN Shirakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
+		ship = { name = "IJN Asashio" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
+		ship = { name = "IJN Harusame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Asagiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Murasame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Ariake" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Arare" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Fubuki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+	}
+	task_force = {
+		name = "5 Sentai"
+		location = 9859 # Tokyo
+		ship = { name = "IJN Shikishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
+		ship = { name = "IJN Asahi" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
+		ship = { name = "IJN Hizen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Retvisan Class" } } }
+		ship = { name = "IJN Akashi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
+		ship = { name = "IJN Hatsushimo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yugure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Harukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yayoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Oite" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hibiki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hatsuyuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yudachi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Nowaki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Mikazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shigure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hatsuharu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Asatsuyu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shirotae" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shiratsuyu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shirayuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Matsukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Nagatsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yunagi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Uzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Minazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hayate" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Kikuzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Uranami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Isonami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Ayanami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+	}
+}
+
+fleet = {
+	name = "3 Sentai Fleet"
+	naval_base = 1136 # Kanazawa
+	task_force = {
+		name = "3 Sentai"
+		location = 1136 # Kanazawa
+		ship = { name = "IJN Kashima" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
+		ship = { name = "IJN Mikasa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Mikasa Class" } } }
+		ship = { name = "IJN Okinoshima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
+		ship = { name = "IJN Chin Yen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Chin Yen Class" } } }
+		ship = { name = "IJN Mishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
+		ship = { name = "IJN Yakumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Yakumo Class" } } }
+		ship = { name = "IJN Adzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Adzumo Class" } } }
+		ship = { name = "IJN Chiyoda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Asama" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+		ship = { name = "IJN Tokiwa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+		ship = { name = "IJN Idzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+	}
+}
+
+fleet = {
+	name = "4 Sentai Fleet"
+	naval_base = 1092 # Hiroshima
+	task_force = {
+		name = "4 Sentai"
+		location = 1092 # Hiroshima
+		ship = { name = "IJN Tango" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Petroplavsk Class" } } }
+		ship = { name = "IJN Fuji" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Fuji Class" } } }
+		ship = { name = "IJN Ikoma" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
+		ship = { name = "IJN Ibuki" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Iwate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+		ship = { name = "IJN Tsugaru" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Pallada Class" } } }
+		ship = { name = "IJN Soya" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Varyag Class" } } }
+		ship = { name = "IJN Naniwa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Takachicho" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Itsukushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
+		ship = { name = "IJN Hashidate" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
+		ship = { name = "IJN Akitsushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Akitsushima Class" } } }
+		ship = { name = "IJN Suma" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
+		ship = { name = "IJN Fumizuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Yamabiko" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Satsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Boiki Class" } } }
+		ship = { name = "IJN Asakaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Wakaba" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Ushio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Ne-no-hi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Kisaragi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Kamikaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+	}
+}
+
+fleet = {
+	name = "6 Sentai Fleet"
+	naval_base = 12068 # Gaoxiong
+	task_force = {
+		name = "6 Sentai"
+		location = 12068 # Gaoxiong
+		ship = { name = "IJN Otowa" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Otowa Class" } } }
+		ship = { name = "IJN Suzya" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Novik Class" } } }
+		ship = { name = "IJN Yodo" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Mogami" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
+		ship = { name = "IJN No. 7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
+		ship = { name = "IJN No. 8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
+	}
+}
+
 	division= { 
 			name = "1 Konoeshidan"
 			location=1182 # Tokyo
@@ -205,150 +358,12 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0
 			}
-	 navy = {
-		name = "1 Sentai"
-		location=9859 # Tokyo
-		base=9859 # Tokyo
-ship = { name = "IJN Sagami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
-ship = { name = "IJN Katori" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
-ship = { name = "IJN Iki" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Imperator Alexander II Class" } } }
-ship = { name = "IJN Kasuga" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Nisshin" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Tsushima" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Akebono" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Ikazuchi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Oboro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Sazanami" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Murakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Kagero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Shinonome" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Shiranui" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Usugumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Yugiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Kasumi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Akatsuki Class" } } }
-
-		}
-	 navy = {
-		name = "2 Sentai"
-		location=9859 # Tokyo
-		base=9859 # Tokyo
-ship = { name = "IJN Iwami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Suwo" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
-ship = { name = "IJN Aso" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Bayan Class" } } }
-ship = { name = "IJN Tsukuba" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
-ship = { name = "IJN Niitaka" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Chitose" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
-ship = { name = "IJN Kasagi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
-ship = { name = "IJN Shirakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
-ship = { name = "IJN Asashio" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
-ship = { name = "IJN Harusame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Asagiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Murasame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Ariake" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Arare" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Fubuki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-
-		}
-	 navy = {
-		name = "3 Sentai"
-		location=1136 # Kanazawa
-		base=1136 # Kanazawa
-ship = { name = "IJN Kashima" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
-ship = { name = "IJN Mikasa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Mikasa Class" } } }
-ship = { name = "IJN Okinoshima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
-ship = { name = "IJN Chin Yen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Chin Yen Class" } } }
-ship = { name = "IJN Mishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
-ship = { name = "IJN Yakumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Yakumo Class" } } }
-ship = { name = "IJN Adzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Adzumo Class" } } }
-ship = { name = "IJN Chiyoda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Asama" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-ship = { name = "IJN Tokiwa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-ship = { name = "IJN Idzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-
-		}
-	 navy = {
-		name = "4 Sentai"
-		location=1092 # Hiroshima
-		base=1092 # Hiroshima
-ship = { name = "IJN Tango" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Petroplavsk Class" } } }
-ship = { name = "IJN Fuji" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Fuji Class" } } }
-ship = { name = "IJN Ikoma" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
-ship = { name = "IJN Ibuki" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Iwate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-ship = { name = "IJN Tsugaru" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Pallada Class" } } }
-ship = { name = "IJN Soya" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Varyag Class" } } }
-ship = { name = "IJN Naniwa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Takachicho" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Itsukushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
-ship = { name = "IJN Hashidate" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
-ship = { name = "IJN Akitsushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Akitsushima Class" } } }
-ship = { name = "IJN Suma" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
-ship = { name = "IJN Fumizuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Yamabiko" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Satsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Boiki Class" } } }
-ship = { name = "IJN Asakaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Wakaba" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Ushio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Ne-no-hi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Kisaragi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Kamikaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-
-		}
-	 navy = {
-		name = "5 Sentai"
-		location=9859 # Tokyo
-		base=9859 # Tokyo
-ship = { name = "IJN Shikishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
-ship = { name = "IJN Asahi" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
-ship = { name = "IJN Hizen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Retvisan Class" } } }
-ship = { name = "IJN Akashi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
-ship = { name = "IJN Hatsushimo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yugure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Harukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yayoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Oite" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hibiki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hatsuyuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yudachi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Nowaki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Mikazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shigure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hatsuharu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Asatsuyu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shirotae" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shiratsuyu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shirayuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Matsukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Nagatsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yunagi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Uzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Minazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hayate" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Kikuzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Uranami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Isonami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Ayanami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-
-		}
-	 navy = {
-		name = "6 Sentai"
-		location = 12068 # Gaoxiong
-		base =  12068 # Gaoxiong
-ship = { name = "IJN Otowa" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Otowa Class" } } }
-ship = { name = "IJN Suzya" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Novik Class" } } }
-ship = { name = "IJN Yodo" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Mogami" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
-ship = { name = "IJN No. 7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
-ship = { name = "IJN No. 8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
-
-		}
+	 
+	 
+	 
+	 
+	 
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/JAP_1914.txt
+++ b/mod/thegreatwar/history/units/JAP_1914.txt
@@ -39,6 +39,168 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "4 Sentai Fleet"
+	naval_base = 1092 # Hiroshima
+	task_force = {
+		name = "4 Sentai"
+		location = 1092 # Hiroshima
+		ship = { name = "IJN Aki" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Satsuma Class" } } }
+		ship = { name = "IJN Tango" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Petroplavsk Class" } } }
+		ship = { name = "IJN Fuji" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Fuji Class" } } }
+		ship = { name = "IJN Ikoma" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
+		ship = { name = "IJN Iwate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+		ship = { name = "IJN Ibuki" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Tsugaru" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Pallada Class" } } }
+		ship = { name = "IJN Soya" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Varyag Class" } } }
+		ship = { name = "IJN Takachicho" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Itsukushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
+		ship = { name = "IJN Hashidate" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
+		ship = { name = "IJN Akitsushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Akitsushima Class" } } }
+		ship = { name = "IJN Suma" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
+		ship = { name = "IJN Akebono" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Oboro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Murakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Kagero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Shiranui" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Usugumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+		ship = { name = "IJN Yugiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
+	}
+}
+
+fleet = {
+	name = "6 Sentai Fleet"
+	naval_base = 12068 # Gaoxiong
+	task_force = {
+		name = "6 Sentai"
+		location = 12068 # Gaoxiong
+		ship = { name = "IJN Tone" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP version_name = "Tone Class" } } }
+		ship = { name = "IJN Yodo" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Mogami" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Chikuma" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Yahagi" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Hirado" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Otowa" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Otowa Class" } } }
+		ship = { name = "IJN No. 1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
+		ship = { name = "IJN No. 7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
+		ship = { name = "IJN No. 8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 11" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN No. 13" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = JAP } } }
+	}
+}
+
+fleet = {
+	name = "1 Sentai Fleet"
+	naval_base = 9859 # Tokyo
+	task_force = {
+		name = "1 Sentai"
+		location = 9859 # Tokyo
+		ship = { name = "IJN Sagami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
+		ship = { name = "IJN Iki" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Imperator Alexander II Class" } } }
+		ship = { name = "IJN Katori" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
+		ship = { name = "IJN Kawachi" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Kurama" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Kasuga" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Nisshin" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Tsushima" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Hatsuyuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yudachi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Nowaki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Mikazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shigure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hatsuharu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shirotae" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shiratsuyu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Shirayuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Matsukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Nagatsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yunagi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Uzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Minazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hayate" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Kikuzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Uranami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Isonami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Ayanami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Umikaze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Yamakaze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Sakura" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Tachibana" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = JAP } } }
+	}
+	task_force = {
+		name = "2 Sentai"
+		location = 9859 # Tokyo
+		ship = { name = "IJN Kongo" definition = battle_cruiser equipment = { battle_cruiser_1914 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Settsu" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Satsuma" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Satsuma Class" } } }
+		ship = { name = "IJN Iwami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Suwo" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
+		ship = { name = "IJN Aso" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Bayan Class" } } }
+		ship = { name = "IJN Tsukuba" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
+		ship = { name = "IJN Chitose" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
+		ship = { name = "IJN Kasagi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
+		ship = { name = "IJN Niitaka" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Arare" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Fubuki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Satsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Boiki Class" } } }
+		ship = { name = "IJN Asakaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Wakaba" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Ushio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Ne-no-hi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Kisaragi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Kamikaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hatsushimo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yugure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Harukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Yayoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Oite" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+		ship = { name = "IJN Hibiki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
+	}
+	task_force = {
+		name = "5 Sentai"
+		location = 9859 # Tokyo
+		ship = { name = "IJN Shikishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
+		ship = { name = "IJN Asahi" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
+		ship = { name = "IJN Hizen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Retvisan Class" } } }
+		ship = { name = "IJN Okinoshima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
+		ship = { name = "IJN Chin Yen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Chin Yen Class" } } }
+		ship = { name = "IJN Akashi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
+		ship = { name = "IJN Kasumi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Akatsuki Class" } } }
+		ship = { name = "IJN Shirakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
+		ship = { name = "IJN Asashio" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
+		ship = { name = "IJN Asagiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Murasame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+		ship = { name = "IJN Ariake" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
+	}
+}
+
+fleet = {
+	name = "3 Sentai Fleet"
+	naval_base = 1136 # Kanazawa
+	task_force = {
+		name = "3 Sentai"
+		location = 1136 # Kanazawa
+		ship = { name = "IJN Kashima" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
+		ship = { name = "IJN Mikasa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Mikasa Class" } } }
+		ship = { name = "IJN Mishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
+		ship = { name = "IJN Yakumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Yakumo Class" } } }
+		ship = { name = "IJN Adzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Adzumo Class" } } }
+		ship = { name = "IJN Chiyoda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP } } }
+		ship = { name = "IJN Asama" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+		ship = { name = "IJN Tokiwa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+		ship = { name = "IJN Idzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
+	}
+}
+
 	division= { 
 			name = "1 Konoeshidan"
 			location=1182 # Tokyo
@@ -189,159 +351,12 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-navy = {
-	name = "1 Sentai"
-	location=9859 # Tokyo
-	base=9859 # Tokyo
-	ship = { name = "IJN Sagami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
-ship = { name = "IJN Iki" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Imperator Alexander II Class" } } }
-ship = { name = "IJN Katori" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
-ship = { name = "IJN Kawachi" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Kurama" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Kasuga" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Nisshin" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Tsushima" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Hatsuyuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yudachi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Nowaki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Mikazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shigure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hatsuharu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shirotae" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shiratsuyu" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Shirayuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Matsukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Nagatsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yunagi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Uzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Minazuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hayate" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Kikuzuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Uranami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Isonami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Ayanami" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Umikaze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Yamakaze" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Sakura" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Tachibana" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = JAP } } }
 
-}
-navy = {
-	name = "2 Sentai"
-	location=9859 # Tokyo
-	base=9859 # Tokyo
-	ship = { name = "IJN Kongo" definition = battle_cruiser equipment = { battle_cruiser_1914 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Settsu" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Satsuma" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Satsuma Class" } } }
-ship = { name = "IJN Iwami" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Suwo" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Peresviet Class" } } }
-ship = { name = "IJN Aso" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Bayan Class" } } }
-ship = { name = "IJN Tsukuba" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
-ship = { name = "IJN Chitose" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
-ship = { name = "IJN Kasagi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Chitose Class" } } }
-ship = { name = "IJN Niitaka" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Arare" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Fubuki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Satsuki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Boiki Class" } } }
-ship = { name = "IJN Asakaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Wakaba" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Ushio" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Ne-no-hi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Kisaragi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Kamikaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hatsushimo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yugure" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Harukaze" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Yayoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Oite" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
-ship = { name = "IJN Hibiki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = JAP version_name = "Asakaze Class" } } }
 
-}
-navy = {
-	name = "3 Sentai"
-	location=1136 # Kanazawa
-	base=1136 # Kanazawa
-ship = { name = "IJN Kashima" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Kashima Class" } } }
-ship = { name = "IJN Mikasa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Mikasa Class" } } }
-ship = { name = "IJN Mishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
-ship = { name = "IJN Yakumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Yakumo Class" } } }
-ship = { name = "IJN Adzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Adzumo Class" } } }
-ship = { name = "IJN Chiyoda" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Asama" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-ship = { name = "IJN Tokiwa" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-ship = { name = "IJN Idzumo" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-}
-navy = {
-	name = "4 Sentai"
-	location=1092 # Hiroshima
-	base=1092 # Hiroshima
-ship = { name = "IJN Aki" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Satsuma Class" } } }
-ship = { name = "IJN Tango" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Petroplavsk Class" } } }
-ship = { name = "IJN Fuji" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Fuji Class" } } }
-ship = { name = "IJN Ikoma" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = JAP version_name = "Tsukuba Class" } } }
-ship = { name = "IJN Iwate" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = JAP version_name = "Asama Class" } } }
-ship = { name = "IJN Ibuki" definition = battle_cruiser equipment = { battle_cruiser_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Tsugaru" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Pallada Class" } } }
-ship = { name = "IJN Soya" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Varyag Class" } } }
-ship = { name = "IJN Takachicho" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Itsukushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
-ship = { name = "IJN Hashidate" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Matshushima Class" } } }
-ship = { name = "IJN Akitsushima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Akitsushima Class" } } }
-ship = { name = "IJN Suma" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
-ship = { name = "IJN Akebono" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Oboro" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Murakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Kagero" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Shiranui" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Usugumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
-ship = { name = "IJN Yugiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Murakumo Class" } } }
 
-}
-navy = {
-	name = "5 Sentai"
-	location=9859 # Tokyo
-	base=9859 # Tokyo
-ship = { name = "IJN Shikishima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
-ship = { name = "IJN Asahi" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Shikishima Class" } } }
-ship = { name = "IJN Hizen" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = JAP version_name = "Retvisan Class" } } }
-ship = { name = "IJN Okinoshima" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Admiral Ushakov Class" } } }
-ship = { name = "IJN Chin Yen" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = JAP version_name = "Chin Yen Class" } } }
-ship = { name = "IJN Akashi" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = JAP version_name = "Suma Class" } } }
-ship = { name = "IJN Kasumi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Akatsuki Class" } } }
-ship = { name = "IJN Shirakumo" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
-ship = { name = "IJN Asashio" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Shirakumo Class" } } }
-ship = { name = "IJN Asagiri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Murasame" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
-ship = { name = "IJN Ariake" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = JAP version_name = "Harusame Class" } } }
 
-}
-	 navy = {
-		name = "6 Sentai"
-		location = 12068 # Gaoxiong
-		base =  12068 # Gaoxiong
-		
-ship = { name = "IJN Tone" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP version_name = "Tone Class" } } }
-ship = { name = "IJN Yodo" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Mogami" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Chikuma" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Yahagi" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Hirado" definition = light_cruiser equipment = { light_cruiser_1910 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN Otowa" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = JAP version_name = "Otowa Class" } } }
-ship = { name = "IJN No. 1" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 2" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 3" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 4" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 5" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 6" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
-ship = { name = "IJN No. 7" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = JAP version_name = "Kaigun-Holland Class" } } }
-ship = { name = "IJN No. 8" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 9" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 10" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 11" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 12" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = JAP } } }
-ship = { name = "IJN No. 13" definition = submarine equipment = { submarine_1910 = { amount = 1 owner = JAP } } }
 
-		}
+	 
 	}
 air_wings = { 
 

--- a/mod/thegreatwar/history/units/MEX_1910.txt
+++ b/mod/thegreatwar/history/units/MEX_1910.txt
@@ -32,6 +32,17 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada de Mexico Fleet"
+	naval_base = 8032 # Acapulco
+	task_force = {
+		name = "Armada de Mexico"
+		location = 8032 # Acapulco
+		ship = { name = "Zaragosa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = MEX } } }
+	}
+}
+
 	division= {
 			name = "1. Ejercito Federal"
 			location = 1965 # Ciudad de México
@@ -150,13 +161,7 @@ units = {
 																			start_experience_factor=0.2
 																			}
 
-						navy = {
-				 		name = "Armada de Mexico"
-				 		location = 8032 # Acapulco
-				 		base =  8032 # Acapulco
-ship = { name = "Zaragosa" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = MEX } } }
-
-				 		}
+						
 				 	}
 air_wings = {
 	}

--- a/mod/thegreatwar/history/units/NOR_1910.txt
+++ b/mod/thegreatwar/history/units/NOR_1910.txt
@@ -32,6 +32,25 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Sjøforsvaret Fleet"
+	naval_base = 9296 # Kristiansand
+	task_force = {
+		name = "Sjøforsvaret"
+		location = 9296 # Kristiansand
+		ship = { name = "KNM Norge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Eidsvold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Harald Haarfagre" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Tordenskjold" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Frithjof" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Viking" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR version_name = "Viking Class" } } }
+		ship = { name = "KNM Valkyrjen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Draug" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Kobben" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = NOR } } }
+	}
+}
+
 	division= { 
 			name = "1. Infanteridivisjon"
 			location=6115 # Oslo
@@ -46,21 +65,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Sjøforsvaret"
-		location = 9296 # Kristiansand
-		base =  9296 # Kristiansand
-ship = { name = "KNM Norge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Eidsvold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Harald Haarfagre" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Tordenskjold" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Frithjof" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Viking" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR version_name = "Viking Class" } } }
-ship = { name = "KNM Valkyrjen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Draug" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Kobben" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = NOR } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/NOR_1914.txt
+++ b/mod/thegreatwar/history/units/NOR_1914.txt
@@ -42,6 +42,30 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Sjøforsvaret Fleet"
+	naval_base = 9296 # Kristiansand
+	task_force = {
+		name = "Sjøforsvaret"
+		location = 9296 # Kristiansand
+		ship = { name = "KNM Norge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Eidsvold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Harald Haarfagre" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Tordenskjold" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Frithjof" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Viking" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR version_name = "Viking Class" } } }
+		ship = { name = "KNM Valkyrjen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Draug" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Troll" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Garm" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM Kobben" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM A2" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM A3" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = NOR } } }
+		ship = { name = "KNM A4" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = NOR } } }
+	}
+}
+
 	division= { 
 			name = "1. Infanteridivisjon"
 			location=6115 # Oslo
@@ -56,26 +80,7 @@ units = {
 			division_template="Mountain Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Sjøforsvaret"
-		location = 9296 # Kristiansand
-		base =  9296 # Kristiansand
-ship = { name = "KNM Norge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Eidsvold" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Harald Haarfagre" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Tordenskjold" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Frithjof" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Viking" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = NOR version_name = "Viking Class" } } }
-ship = { name = "KNM Valkyrjen" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Draug" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Troll" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Garm" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM Kobben" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM A2" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM A3" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = NOR } } }
-ship = { name = "KNM A4" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = NOR } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/NZL_1910.txt
+++ b/mod/thegreatwar/history/units/NZL_1910.txt
@@ -33,6 +33,19 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Royal New Zealand Navy Fleet"
+	naval_base = 1814 # Wellington
+	task_force = {
+		name = "Royal New Zealand Navy"
+		location = 1814 # Wellington
+		ship = { name = "HMNZS Philomel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Pearl Class" } } }
+		ship = { name = "HMNZS Pyramus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMNZS Psyche" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st NZ Infantry Division"
 			location=1814 # Wellington
@@ -59,17 +72,7 @@ units = {
 			# start_equipment_factor = 0.3 
 			# start_manpower_factor = 0.3
 			}
-	 navy = {
-		name = "Royal New Zealand Navy"
-		location=1814 # Wellington
-		base=1814 # Wellington
-
-ship = { name = "HMNZS Philomel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Pearl Class" } } }
-ship = { name = "HMNZS Pyramus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMNZS Psyche" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-
-
-		}
+	 
 }
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/NZL_1914.txt
+++ b/mod/thegreatwar/history/units/NZL_1914.txt
@@ -32,6 +32,19 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Royal New Zealand Navy Fleet"
+	naval_base = 1814 # Wellington
+	task_force = {
+		name = "Royal New Zealand Navy"
+		location = 1814 # Wellington
+		ship = { name = "HMS Psyche" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Pyramus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
+		ship = { name = "HMS Philomel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Pearl Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st NZ Infantry Division"
 			location=1814 # Wellington
@@ -58,15 +71,7 @@ units = {
 			# start_equipment_factor = 0.3 
 			# start_manpower_factor = 0.3
 			}
-	 navy = {
-		name = "Royal New Zealand Navy"
-		location=1814 # Wellington
-		base=1814 # Wellington
-ship = { name = "HMS Psyche" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Pyramus" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = ENG version_name = "Pelorus Class" } } }
-ship = { name = "HMS Philomel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ENG version_name = "Pearl Class" } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/POR_1910.txt
+++ b/mod/thegreatwar/history/units/POR_1910.txt
@@ -34,6 +34,23 @@ division_template = {
 
 
 units = {
+
+fleet = {
+	name = "Armada Portuguesa Fleet"
+	naval_base = 11805 # Lisboa
+	task_force = {
+		name = "Armada Portuguesa"
+		location = 11805 # Lisboa
+		ship = { name = "Vasco Da Gama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = POR } } }
+		ship = { name = "Adamastor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR } } }
+		ship = { name = "São Gabriel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "São Gabriel Class" } } }
+		ship = { name = "São Rafael" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "São Gabriel Class" } } }
+		ship = { name = "Almirante Reis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "Dom Carlos I Class" } } }
+		ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = POR } } }
+		ship = { name = "Tejo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = POR } } }
+	}
+}
+
 	division= { 
 			name = "1o Batalhão de Infantaria"
 			location = 11805 # Lisboa
@@ -48,19 +65,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.1
 			}
- 	navy = {
-		name = "Armada Portuguesa"
-		location = 11805 # Lisboa
-		base =  11805 # Lisboa
-ship = { name = "Vasco Da Gama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = POR } } }
-ship = { name = "Adamastor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR } } }
-ship = { name = "São Gabriel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "São Gabriel Class" } } }
-ship = { name = "São Rafael" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "São Gabriel Class" } } }
-ship = { name = "Almirante Reis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "Dom Carlos I Class" } } }
-ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = POR } } }
-ship = { name = "Tejo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = POR } } }
-
-	}
+ 	
 }
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/POR_1914.txt
+++ b/mod/thegreatwar/history/units/POR_1914.txt
@@ -33,6 +33,24 @@ division_template = {
 
 
 units = {
+
+fleet = {
+	name = "Armada Portuguesa Fleet"
+	naval_base = 11805 # Lisboa
+	task_force = {
+		name = "Armada Portuguesa"
+		location = 11805 # Lisboa
+		ship = { name = "Vasco Da Gama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = POR } } }
+		ship = { name = "Adamastor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR } } }
+		ship = { name = "São Gabriel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "São Gabriel Class" } } }
+		ship = { name = "Almirante Reis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "Dom Carlos I Class" } } }
+		ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = POR } } }
+		ship = { name = "Tejo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = POR } } }
+		ship = { name = "Douro" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = POR } } }
+		ship = { name = "Espadarte" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = POR } } }
+	}
+}
+
 	division= { 
 			name = "1o Batalhão de Infantaria"
 			location = 11805 # Lisboa
@@ -47,20 +65,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Armada Portuguesa"
-		location = 11805 # Lisboa
-		base =  11805 # Lisboa
-ship = { name = "Vasco Da Gama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = POR } } }
-ship = { name = "Adamastor" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR } } }
-ship = { name = "São Gabriel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "São Gabriel Class" } } }
-ship = { name = "Almirante Reis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = POR version_name = "Dom Carlos I Class" } } }
-ship = { name = "República" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = POR } } }
-ship = { name = "Tejo" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = POR } } }
-ship = { name = "Douro" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = POR } } }
-ship = { name = "Espadarte" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = POR } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/PRU_1910.txt
+++ b/mod/thegreatwar/history/units/PRU_1910.txt
@@ -32,6 +32,19 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Marina del Guerra del Peru Fleet"
+	naval_base = 12997 # Lima
+	task_force = {
+		name = "Marina del Guerra del Peru"
+		location = 12997 # Lima
+		ship = { name = "ARP Lima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = PRU } } }
+		ship = { name = "ARP Almirante Grau" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
+		ship = { name = "ARP Coronel Bolognesi" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
+	}
+}
+
 	division= { 
 			name = "1a Div. de Inf. del Peru 'Bolognesi'"
 			location=12997 # Lima
@@ -62,15 +75,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.02
 			}
-	 navy = {
-		name = "Marina del Guerra del Peru"
-		location=12997 # Lima
-		base=12997 # Lima
-ship = { name = "ARP Lima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = PRU } } }
-ship = { name = "ARP Almirante Grau" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
-ship = { name = "ARP Coronel Bolognesi" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/PRU_1914.txt
+++ b/mod/thegreatwar/history/units/PRU_1914.txt
@@ -32,6 +32,21 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Marina del Guerra del Peru Fleet"
+	naval_base = 12997 # Lima
+	task_force = {
+		name = "Marina del Guerra del Peru"
+		location = 12997 # Lima
+		ship = { name = "ARP Lima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = PRU } } }
+		ship = { name = "ARP Almirante Grau" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
+		ship = { name = "ARP Coronel Bolognesi" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
+		ship = { name = "ARP Ferre" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = PRU } } }
+		ship = { name = "ARP Palacios" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = PRU } } }
+	}
+}
+
 	division= { 
 			name = "1a Div. de Inf. del Peru 'Bolognesi'"
 			location=12997 # Lima
@@ -62,17 +77,7 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0.02
 			}
-	 navy = {
-		name = "Marina del Guerra del Peru"
-		location=12997 # Lima
-		base=12997 # Lima
-ship = { name = "ARP Lima" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = PRU } } }
-ship = { name = "ARP Almirante Grau" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
-ship = { name = "ARP Coronel Bolognesi" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = PRU } } }
-ship = { name = "ARP Ferre" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = PRU } } }
-ship = { name = "ARP Palacios" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = PRU } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/QIN_1910.txt
+++ b/mod/thegreatwar/history/units/QIN_1910.txt
@@ -27,6 +27,39 @@ division_template = {
 ###################################################################
 units = {
 
+fleet = {
+	name = "Changjiang Fleet Fleet"
+	naval_base = 7014 # Shanghai
+	task_force = {
+		name = "Xunyang Fleet"
+		location = 7014 # Shanghai
+		ship = { name = "Hai Yung" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Yung Class" } } }
+		ship = { name = "Hai Chou" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Yung Class" } } }
+		ship = { name = "Hai Tan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Yung Class" } } }
+		ship = { name = "Hai Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Tien Class" } } }
+		ship = { name = "Tung Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Tung Chi Class" } } }
+		ship = { name = "Pao Min" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Pao Min Class" } } }
+	}
+	task_force = {
+		name = "Changjiang Fleet"
+		location = 7014 # Shanghai
+		ship = { name = "Chao Wu" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN } } }
+		ship = { name = "Fu Po" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
+		ship = { name = "Yuan Kai" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
+		ship = { name = "Teng Ying Chou" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
+		ship = { name = "Tai An" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
+		ship = { name = "Chen Hang" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Hai Ching Class" } } }
+		ship = { name = "Nan Jui" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Nan Tan Class" } } }
+		ship = { name = "King Ching" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN } } }
+		ship = { name = "Fu An" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Tung Chi Class" } } }
+		ship = { name = "Hu Peng" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
+		ship = { name = "Hu Ngo" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
+		ship = { name = "Hu Chung" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
+		ship = { name = "Hu Ying" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
+	}
+}
+
+
 #	division= { 
 #			name = "Nine Gates Banner Garrison"
 #			location = 9843 # Beiping
@@ -283,42 +316,8 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0
 			}
-	 navy = {
-		name = "Xunyang Fleet"
-		location=7014 # Shanghai
-		base=7014 # Shanghai
-
-
-ship = { name = "Hai Yung" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Yung Class" } } }
-ship = { name = "Hai Chou" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Yung Class" } } }
-ship = { name = "Hai Tan" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Yung Class" } } }
-ship = { name = "Hai Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Hai Tien Class" } } }
-ship = { name = "Tung Chi" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Tung Chi Class" } } }
-ship = { name = "Pao Min" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Pao Min Class" } } }
-
-
-		}
-	 navy = {
-		name = "Changjiang Fleet"
-		location=7014 # Shanghai
-		base=7014 # Shanghai
-		
-ship = { name = "Chao Wu" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN } } }
-ship = { name = "Fu Po" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
-ship = { name = "Yuan Kai" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
-ship = { name = "Teng Ying Chou" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
-ship = { name = "Tai An" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Fu Po Class" } } }
-ship = { name = "Chen Hang" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Hai Ching Class" } } }
-ship = { name = "Nan Jui" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = QIN version_name = "Nan Tan Class" } } }
-ship = { name = "King Ching" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN } } }
-ship = { name = "Fu An" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = QIN version_name = "Tung Chi Class" } } }
-ship = { name = "Hu Peng" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
-ship = { name = "Hu Ngo" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
-ship = { name = "Hu Chung" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
-ship = { name = "Hu Ying" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = QIN } } }
-
-
-		}
+	 
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/ROM_1910.txt
+++ b/mod/thegreatwar/history/units/ROM_1910.txt
@@ -38,6 +38,17 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Flota Marii Negre Fleet"
+	naval_base = 657 # Constanta
+	task_force = {
+		name = "Flota Marii Negre"
+		location = 657 # Constanta
+		ship = { name = "NMS Elisabeta" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ROM } } }
+	}
+}
+
 	division= { 
 			name = "Divizia 1 Infanterie"
 			location = 3645 # Craiova
@@ -140,13 +151,7 @@ units = {
 			division_template="Cavalry Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Flota Marii Negre"
-		location = 657 # Constanta
-		base =  657 # Constanta
-ship = { name = "NMS Elisabeta" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ROM } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/ROM_1914.txt
+++ b/mod/thegreatwar/history/units/ROM_1914.txt
@@ -38,6 +38,17 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Flota Marii Negre Fleet"
+	naval_base = 657 # Constanta
+	task_force = {
+		name = "Flota Marii Negre"
+		location = 657 # Constanta
+		ship = { name = "NMS Elisabeta" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ROM } } }
+	}
+}
+
 	division= { 
 			name = "Divizia 1 Infanterie"
 			location = 3645 # Craiova
@@ -188,13 +199,7 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Flota Marii Negre"
-		location = 657 # Constanta
-		base =  657 # Constanta
-ship = { name = "NMS Elisabeta" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = ROM } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/RUS_1910.txt
+++ b/mod/thegreatwar/history/units/RUS_1910.txt
@@ -94,6 +94,219 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Baltiysky Flot Fleet"
+	naval_base = 3151 # St. Petersburg
+	task_force = {
+		name = "Baltiysky Flot"
+		location = 3151 # St. Petersburg
+		ship = { name = "Tsesarevich" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tsesarevich Class" } } }
+		ship = { name = "Imperator Alexander II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Imperator Alexander II Class" } } }
+		ship = { name = "Dvienadtsat Apostolov" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Dvienadtsat Apostolov Class" } } }
+		ship = { name = "Georgi Pobiedonosets" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
+		ship = { name = "Sinop" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
+		ship = { name = "Petr Veliki" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Petr Veliki Class" } } }
+		ship = { name = "Slava" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Minin" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Minin Class" } } }
+		ship = { name = "Admiral Makarov" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
+		ship = { name = "Bayan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
+		ship = { name = "Rurik" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Rurik Class" } } }
+		ship = { name = "General-Admiral" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
+		ship = { name = "Gerzog Edinburgski" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
+		ship = { name = "Pamiat Azova" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pamiat Azova Class" } } }
+		ship = { name = "Bogatyr" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Oleg" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Admiral Kornilov" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Admiral Kornilov Class" } } }
+		ship = { name = "Avrora" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
+		ship = { name = "Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
+		ship = { name = "Rossia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Gromoboi" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Prytky" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Podvizhni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Porazhayuschi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Poslushni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Prochni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Pronzitelni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Prozorlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Pylki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Retivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Rezvi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Ryani" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Serditi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Skori" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Smyeli" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Smyetlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Statni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Stremitelni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Strogi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Sviryepi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Bezposhchadni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Bezshumni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Beztrashni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Bodri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Boiki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Bravi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Vidni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Grozovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Vlastni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Gromyaschi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
+		ship = { name = "Grozni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
+		ship = { name = "Zadorni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zavetni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zavidni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zorki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zvonki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zharki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zhivoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zhivuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zhutki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Inzhener-Mekhanik Anastasov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Leitenant Maleev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Tochni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Trevozhni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Tverdi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Iskusni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Ispolnitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Krepki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Legki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Leitenant Burakov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Letuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Likhoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Lovki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Metki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Molodetski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Moshchni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Bditelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Boevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Burni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Inzhener-Mekhanik Dmitriev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Inzhener-Mekhanik Zverev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Kapitan Yurasovski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Leitenant Sergeev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Vnimatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Vnushitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Vynoslivi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Podvizhny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Porazhayushchy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Poslushny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Prochny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Pronzitelny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Prozorlivy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Pylky" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Retivy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Rezvy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Ryany" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Serdity" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Skory" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Smely" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Smetlivy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Statny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Stremitelny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Strogy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Svirepy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Besposhchadny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+	}
+	task_force = {
+		name = "Baltiyskaya Podvodnaya Flotiliya"
+		location = 3151 # St. Petersburg
+		ship = { name = "Delfin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Feldmarshal Graf Sheremetev" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Kasatka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Makrel" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Nalim" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Okun" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Skat" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Beluga" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Losos" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Peskar" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Shchuka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Som" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Sterlyad" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Sudak" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+	}
+}
+
+fleet = {
+	name = "Chernomorskaya Podvodnaya Flotiliya Fleet"
+	naval_base = 3686 # Sevastopol
+	task_force = {
+		name = "Chernomorsky Flot"
+		location = 3686 # Sevastopol
+		ship = { name = "Tri Svititelia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tri Svititelia Class" } } }
+		ship = { name = "Rotislav" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Rotislav Class" } } }
+		ship = { name = "Pantelimon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Kniaz Potemkin Class" } } }
+		ship = { name = "Kagul" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Ochakov" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Dyelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Dyeyatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Dostoini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Rastoropni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Razyashchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Silni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Storozhevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Stroini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Tri Svyatitelya" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }
+	}
+	task_force = {
+		name = "Chernomorskaya Podvodnaya Flotiliya"
+		location = 3686 # Sevastopol
+		ship = { name = "Bychek" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Kefal" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Osetr" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Paltus" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Plotva" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Sig" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Karp" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Karas" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Kaiman" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Alligator" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Drakon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Krokodil" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Minoga" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Minoga Class" } } }
+		ship = { name = "Akula" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = RUS } } }
+		ship = { name = "Pochtovy" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = RUS version_name = "Pochtovy Class" } } }
+		ship = { name = "Bychyok" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+	}
+}
+
+fleet = {
+	name = "Sibirskaya Flotiliya Fleet"
+	naval_base = 957 # Vladivostok
+	task_force = {
+		name = "Sibirskaya Flotiliya"
+		location = 957 # Vladivostok
+		ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Askold Class" } } }
+		ship = { name = "Almaz" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Zhemchug" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS version_name = "Zhemchug Class" } } }
+		ship = { name = "Donskoi Kazak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Kazanets" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Sterehushchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Strashni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Turkmenetz-Stavropolski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Ukraina" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Vojskovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Zabajkaletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Dobrovoletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Emir Bukharski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Finn" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Moskvityanin" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Amuretz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "Gaidamak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "Ussurietz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "Vsadnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "General Kondratenko" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Okhotnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Pogranichnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Sibirski Stryelok" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Kapitan-Leitenant Baranov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Leitenant Pushchin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Leitenant Shestakov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Leitenant Zatsarenni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }
+	}
+}
+
 	division= {
 			name = "1-ya Diviziya Opolcheniya"
 			location = 11121 # Petsamo
@@ -1541,116 +1754,7 @@ units = {
 			start_manpower_factor = 0.3
 			}
 
-	 navy = {
-		name = "Baltiysky Flot"
-		location = 3151 # St. Petersburg
-		base =  3151 # St. Petersburg
-ship = { name = "Tsesarevich" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tsesarevich Class" } } }
-ship = { name = "Imperator Alexander II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Imperator Alexander II Class" } } }
-ship = { name = "Dvienadtsat Apostolov" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Dvienadtsat Apostolov Class" } } }
-ship = { name = "Georgi Pobiedonosets" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
-ship = { name = "Sinop" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
-ship = { name = "Petr Veliki" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Petr Veliki Class" } } }
-ship = { name = "Slava" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Minin" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Minin Class" } } }
-ship = { name = "Admiral Makarov" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
-ship = { name = "Bayan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
-ship = { name = "Rurik" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Rurik Class" } } }
-ship = { name = "General-Admiral" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
-ship = { name = "Gerzog Edinburgski" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
-ship = { name = "Pamiat Azova" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pamiat Azova Class" } } }
-ship = { name = "Bogatyr" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Oleg" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Admiral Kornilov" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Admiral Kornilov Class" } } }
-ship = { name = "Avrora" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
-ship = { name = "Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
-ship = { name = "Rossia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Gromoboi" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Prytky" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Podvizhni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Porazhayuschi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Poslushni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Prochni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Pronzitelni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Prozorlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Pylki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Retivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Rezvi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Ryani" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Serditi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Skori" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Smyeli" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Smyetlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Statni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Stremitelni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Strogi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Sviryepi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Bezposhchadni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Bezshumni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Beztrashni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Bodri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Boiki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Bravi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Vidni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Grozovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Vlastni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Gromyaschi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
-ship = { name = "Grozni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
-ship = { name = "Zadorni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zavetni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zavidni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zorki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zvonki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zharki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zhivoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zhivuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zhutki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Inzhener-Mekhanik Anastasov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Leitenant Maleev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Tochni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Trevozhni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Tverdi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Iskusni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Ispolnitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Krepki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Legki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Leitenant Burakov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Letuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Likhoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Lovki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Metki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Molodetski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Moshchni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Bditelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Boevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Burni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Inzhener-Mekhanik Dmitriev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Inzhener-Mekhanik Zverev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Kapitan Yurasovski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Leitenant Sergeev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Vnimatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Vnushitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Vynoslivi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-
-#ship = { name = "Podvizhny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Porazhayushchy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Poslushny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Prochny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Pronzitelny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Prozorlivy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Pylky" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Retivy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Rezvy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Ryany" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Serdity" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Skory" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Smely" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Smetlivy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Statny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Stremitelny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Strogy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Svirepy" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-#ship = { name = "Besposhchadny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bditelni Class" } } }
+	  } }
 #ship = { name = "Bezshumny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bditelni Class" } } }
 #ship = { name = "Bezstrashny" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bditelni Class" } } }
 #ship = { name = "Bodry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Boiki Class" } } }
@@ -1697,46 +1801,8 @@ ship = { name = "Vynoslivi" definition = destroyer equipment = { destroyer_1900 
 #ship = { name = "Vnushitelny" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bditelni Class" } } }
 #ship = { name = "Vynoslivy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bditelni Class" } } }
 		}
-	 navy = {
-		name = "Baltiyskaya Podvodnaya Flotiliya"
-		location = 3151 # St. Petersburg
-		base =  3151 # St. Petersburg
-ship = { name = "Delfin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Feldmarshal Graf Sheremetev" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Kasatka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Makrel" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Nalim" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Okun" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Skat" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Beluga" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Losos" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Peskar" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Shchuka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Som" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Sterlyad" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Sudak" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-
-		}
-	 navy = {
-		name = "Chernomorsky Flot"
-		location=3686 # Sevastopol
-		base=3686 # Sevastopol
-ship = { name = "Tri Svititelia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tri Svititelia Class" } } }
-ship = { name = "Rotislav" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Rotislav Class" } } }
-ship = { name = "Pantelimon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Kniaz Potemkin Class" } } }
-ship = { name = "Kagul" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Ochakov" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Dyelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Dyeyatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Dostoini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Rastoropni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Razyashchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Silni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Storozhevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Stroini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-		
-
-#ship = { name = "Tri Svyatitelya" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Tri Svititelia Class" } } }
+	 
+	  } }
 #ship = { name = "Rostislav" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Rotislav Class" } } }
 #ship = { name = "Panteleymon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kniaz Potemkin Class" } } }
 #ship = { name = "Kagul" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bogatyr Class" } } }
@@ -1750,29 +1816,7 @@ ship = { name = "Stroini" definition = destroyer equipment = { destroyer_1900 = 
 #ship = { name = "Storozhevoy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Storozhevoi Class" } } }
 #ship = { name = "Stroyny" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Storozhevoi Class" } } }
 		}
-	 navy = {
-		name = "Chernomorskaya Podvodnaya Flotiliya"
-		location=3686 # Sevastopol
-		base=3686 # Sevastopol
-		
-ship = { name = "Bychek" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-ship = { name = "Kefal" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-ship = { name = "Osetr" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-ship = { name = "Paltus" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-ship = { name = "Plotva" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-ship = { name = "Sig" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-ship = { name = "Karp" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Karas" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Kaiman" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Alligator" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Drakon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Krokodil" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Minoga" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Minoga Class" } } }
-ship = { name = "Akula" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = RUS } } }
-ship = { name = "Pochtovy" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = RUS version_name = "Pochtovy Class" } } }
-		
-		
-#ship = { name = "Bychyok" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Lake Class" } } }
+	  } }
 #ship = { name = "Kefal" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Lake Class" } } }
 #ship = { name = "Osyotr" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Lake Class" } } }
 #ship = { name = "Paltus" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Lake Class" } } }
@@ -1788,40 +1832,7 @@ ship = { name = "Pochtovy" definition = submarine equipment = { coastal_submarin
 #ship = { name = "Akula" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
 #ship = { name = "Pochtovy" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Pochtovy Class" } } }
 		}
-	 navy = {
-		name = "Sibirskaya Flotiliya"
-		location=957 # Vladivostok
-		base=957 # Vladivostok
-		
-ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Askold Class" } } }
-ship = { name = "Almaz" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Zhemchug" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS version_name = "Zhemchug Class" } } }
-ship = { name = "Donskoi Kazak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Kazanets" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Sterehushchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Strashni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Turkmenetz-Stavropolski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Ukraina" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Vojskovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Zabajkaletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Dobrovoletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Emir Bukharski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Finn" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Moskvityanin" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Amuretz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "Gaidamak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "Ussurietz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "Vsadnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "General Kondratenko" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Okhotnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Pogranichnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Sibirski Stryelok" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Kapitan-Leitenant Baranov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Leitenant Pushchin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Leitenant Shestakov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Leitenant Zatsarenni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-
-#ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Askold Class" } } }
+	  } }
 #ship = { name = "Almaz" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }
 #ship = { name = "Zhemchug" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }
 #ship = { name = "Donskoy Kazak" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Ukraina Class" } } }

--- a/mod/thegreatwar/history/units/RUS_1914.txt
+++ b/mod/thegreatwar/history/units/RUS_1914.txt
@@ -97,6 +97,209 @@ division_template = {
 
 
 units = {
+
+fleet = {
+	name = "Baltiysky Flot Fleet"
+	naval_base = 3151 # St. Petersburg
+	task_force = {
+		name = "Baltiysky Flot"
+		location = 3151 # St. Petersburg
+		ship = { name = "Tsesarevich" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tsesarevich Class" } } }
+		ship = { name = "Petr Veliki" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Petr Veliki Class" } } }
+		ship = { name = "Georgi Pobiedonosets" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
+		ship = { name = "Sinop" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
+		ship = { name = "Imperator Alexander II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Imperator Alexander II Class" } } }
+		ship = { name = "Slava" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Andrei Pervozvanny" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Imperator Pavel I Class" } } }
+		ship = { name = "Imperator Pavel I" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Imperator Pavel I Class" } } }
+		ship = { name = "Admiral Makarov" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
+		ship = { name = "Bayan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
+		ship = { name = "Pallada" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
+		ship = { name = "Rurik" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Rurik Class" } } }
+		ship = { name = "Rossia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Gromoboi" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Minin" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Minin Class" } } }
+		ship = { name = "General-Admiral" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
+		ship = { name = "Gerzog Edinburgski" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
+		ship = { name = "Pamiat Azova" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pamiat Azova Class" } } }
+		ship = { name = "Aurora" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
+		ship = { name = "Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
+		ship = { name = "Bogatyr" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Oleg" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Pruitki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Podvizhni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Porazhayuschi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Poslushni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Prochni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Prozorlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Retivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Rezvi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Ryani" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Serditi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Skori" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Smyeli" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Smyetlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Statni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Stremitelni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Strogi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Sviryepi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
+		ship = { name = "Bezposhchadni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Bezshumni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Beztrashni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Bodri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Boiki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Bravi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Vidni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
+		ship = { name = "Grozovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Vlastni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Gromyaschi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
+		ship = { name = "Grozni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
+		ship = { name = "Zadorni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zavetni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zavidni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zorki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zvonki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zharki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zhivoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zhivuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Zhutki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
+		ship = { name = "Inzhener-Mekhanik Anastasov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Leitenant Maleev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Tochni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Trevozhni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Tverdi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
+		ship = { name = "Iskusni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Ispolnitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Krepki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Legki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Leitenant Burakov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Letuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Likhoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Lovki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Metki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Molodetski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Moshchni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
+		ship = { name = "Bditelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Boevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Burni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Inzhener-Mekhanik Dmitriev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Inzhener-Mekhanik Zverev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Kapitan Yurasovski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Leitenant Sergeev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Vnimatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Vnushitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Vynoslivi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
+		ship = { name = "Tsesarevich" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }
+	}
+	task_force = {
+		name = "Baltiyskaya Podvodnaya Flotiliya"
+		location = 3151 # St. Petersburg
+		ship = { name = "Karp" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Karas" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Kaiman" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Alligator" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Drakon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Krokodil" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
+		ship = { name = "Minoga" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Minoga Class" } } }
+		ship = { name = "Akula" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = RUS } } }
+		ship = { name = "Krab" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Morzh" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS version_name = "Morzh Class" } } }
+		ship = { name = "Nerpa" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS version_name = "Morzh Class" } } }
+		ship = { name = "Tyulen" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS version_name = "Morzh Class" } } }
+		ship = { name = "Karp" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Karas" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Kaiman" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+	}
+}
+
+fleet = {
+	name = "Chernomorskaya Podvodnaya Flotiliya Fleet"
+	naval_base = 3686 # Sevastopol
+	task_force = {
+		name = "Chernomorsky Flot"
+		location = 3686 # Sevastopol
+		ship = { name = "Tri Svititelia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tri Svititelia Class" } } }
+		ship = { name = "Rotislav" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Rotislav Class" } } }
+		ship = { name = "Pantelimon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Kniaz Potemkin Class" } } }
+		ship = { name = "Evstafi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Ioann Zlatoust Class" } } }
+		ship = { name = "Ioann Zlatoust" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Ioann Zlatoust Class" } } }
+		ship = { name = "Kagul" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Ochakov" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
+		ship = { name = "Almaz" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Dyelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Dyeyatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Dostoini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Rastoropni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Razyashchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Silni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Storozhevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Stroini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
+		ship = { name = "Tri Svyatitelya" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }
+	}
+	task_force = {
+		name = "Chernomorskaya Podvodnaya Flotiliya"
+		location = 3686 # Sevastopol
+		ship = { name = "Delfin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS } } }
+		ship = { name = "Feldmarshal Graf Sheremetev" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Kasatka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Makrel" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Nalim" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Okun" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Skat" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
+		ship = { name = "Beluga" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Losos" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Peskar" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Shchuka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Som" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Sterlyad" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Sudak" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
+		ship = { name = "Kefal" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Sig" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
+		ship = { name = "Delfin" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Feldmarshal Graf Sheremetev" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
+	}
+}
+
+fleet = {
+	name = "Sibirskaya Flotiliya Fleet"
+	naval_base = 957 # Vladivostok
+	task_force = {
+		name = "Sibirskaya Flotiliya"
+		location = 957 # Vladivostok
+		ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Askold Class" } } }
+		ship = { name = "Zhemchug" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS version_name = "Zhemchug Class" } } }
+		ship = { name = "Donskoi Kazak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Kazanets" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Sterehushchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Strashni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Turkmenetz-Stavropolski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Ukraina" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Vojskovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Zabajkaletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
+		ship = { name = "Dobrovoletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Emir Bukharski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Finn" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Moskvityanin" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
+		ship = { name = "Amuretz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "Gaidamak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "Ussurietz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "Vsadnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
+		ship = { name = "General Kondratenko" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Okhotnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Pogranichnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Sibirski Stryelok" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
+		ship = { name = "Kapitan-Leitenant Baranov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Leitenant Pushchin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Leitenant Shestakov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Leitenant Zatsarenni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
+		ship = { name = "Novik" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS version_name = "Novik Class" } } }
+		ship = { name = "Bespokoiny" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = RUS } } }
+		ship = { name = "Gnevny" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = RUS } } }
+		ship = { name = "Gromki" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = RUS } } }
+		ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }
+	}
+}
+
 	division= {
 			name = "1-ya Diviziya Opolcheniya"
 			location = 11121 # Petsamo
@@ -1859,97 +2062,7 @@ units = {
 			start_equipment_factor = 0.3
 			start_manpower_factor = 0.3
 			}
-	 navy = {
-		name = "Baltiysky Flot"
-		location = 3151 # St. Petersburg
-		base =  3151 # St. Petersburg
-		ship = { name = "Tsesarevich" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tsesarevich Class" } } }
-ship = { name = "Petr Veliki" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Petr Veliki Class" } } }
-ship = { name = "Georgi Pobiedonosets" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
-ship = { name = "Sinop" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Ekatarina II Class" } } }
-ship = { name = "Imperator Alexander II" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Imperator Alexander II Class" } } }
-ship = { name = "Slava" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Andrei Pervozvanny" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Imperator Pavel I Class" } } }
-ship = { name = "Imperator Pavel I" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Imperator Pavel I Class" } } }
-ship = { name = "Admiral Makarov" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
-ship = { name = "Bayan" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
-ship = { name = "Pallada" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Bayan Class" } } }
-ship = { name = "Rurik" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS version_name = "Rurik Class" } } }
-ship = { name = "Rossia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Gromoboi" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Minin" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Minin Class" } } }
-ship = { name = "General-Admiral" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
-ship = { name = "Gerzog Edinburgski" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "General-Admiral Class" } } }
-ship = { name = "Pamiat Azova" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pamiat Azova Class" } } }
-ship = { name = "Aurora" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
-ship = { name = "Diana" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Pallada Class" } } }
-ship = { name = "Bogatyr" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Oleg" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Pruitki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Podvizhni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Porazhayuschi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Poslushni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Prochni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Prozorlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Retivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Rezvi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Ryani" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Serditi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Skori" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Smyeli" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Smyetlivi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Statni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Stremitelni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Strogi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Sviryepi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS } } }
-ship = { name = "Bezposhchadni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Bezshumni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Beztrashni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Bodri" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Boiki" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Bravi" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Vidni" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = RUS version_name = "Boiki Class" } } }
-ship = { name = "Grozovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Vlastni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Gromyaschi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
-ship = { name = "Grozni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Grozni Class" } } }
-ship = { name = "Zadorni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zavetni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zavidni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zorki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zvonki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zharki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zhivoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zhivuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Zhutki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Z Class" } } }
-ship = { name = "Inzhener-Mekhanik Anastasov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Leitenant Maleev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Tochni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Trevozhni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Tverdi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Tverdi Class" } } }
-ship = { name = "Iskusni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Ispolnitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Krepki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Legki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Leitenant Burakov" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Letuchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Likhoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Lovki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Metki" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Molodetski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Moshchni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Lovki Class" } } }
-ship = { name = "Bditelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Boevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Burni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Inzhener-Mekhanik Dmitriev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Inzhener-Mekhanik Zverev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Kapitan Yurasovski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Leitenant Sergeev" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Vnimatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Vnushitelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-ship = { name = "Vynoslivi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Bditelni Class" } } }
-
-#ship = { name = "Tsesarevich" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Tsesarevich Class" } } }
+	  } }
 #ship = { name = "Pyotr Veliky" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Petr Veliki Class" } } }
 #ship = { name = "Georgy Pobedonosets" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Ekatarina II Class" } } }
 #ship = { name = "Sinop" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Ekatarina II Class" } } }
@@ -2035,28 +2148,7 @@ ship = { name = "Vynoslivi" definition = destroyer equipment = { destroyer_1900 
 #ship = { name = "Vnushitelny" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bditelni Class" } } }
 #ship = { name = "Vynoslivy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Bditelni Class" } } }
 		}
-	 navy = {
-		name = "Baltiyskaya Podvodnaya Flotiliya"
-		location = 3151 # St. Petersburg
-		base =  3151 # St. Petersburg
-ship = { name = "Karp" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Karas" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Kaiman" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Alligator" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Drakon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Krokodil" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Kaiman Class" } } }
-ship = { name = "Minoga" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS version_name = "Minoga Class" } } }
-ship = { name = "Akula" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = RUS } } }
-ship = { name = "Krab" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Morzh" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS version_name = "Morzh Class" } } }
-ship = { name = "Nerpa" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS version_name = "Morzh Class" } } }
-ship = { name = "Tyulen" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS version_name = "Morzh Class" } } }
-		
-		
-
-#ship = { name = "Karp" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
-#ship = { name = "Karas" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
-#ship = { name = "Kaiman" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kaiman Class" } } }
+	  } }
 #ship = { name = "Alligator" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kaiman Class" } } }
 #ship = { name = "Drakon" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kaiman Class" } } }
 #ship = { name = "Krokodil" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kaiman Class" } } }
@@ -2067,29 +2159,7 @@ ship = { name = "Tyulen" definition = submarine equipment = { submarine_1906 = {
 #ship = { name = "Nerpa" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Morzh Class" } } }
 #ship = { name = "Tyulen" definition = submarine equipment = { submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Morzh Class" } } }
 		}
-	 navy = {
-		name = "Chernomorsky Flot"
-		location=3686 # Sevastopol
-		base=3686 # Sevastopol
-		
-ship = { name = "Tri Svititelia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Tri Svititelia Class" } } }
-ship = { name = "Rotislav" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Rotislav Class" } } }
-ship = { name = "Pantelimon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS version_name = "Kniaz Potemkin Class" } } }
-ship = { name = "Evstafi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Ioann Zlatoust Class" } } }
-ship = { name = "Ioann Zlatoust" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = RUS version_name = "Ioann Zlatoust Class" } } }
-ship = { name = "Kagul" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Ochakov" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Bogatyr Class" } } }
-ship = { name = "Almaz" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Dyelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Dyeyatelni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Dostoini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Rastoropni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Razyashchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Silni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Storozhevoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-ship = { name = "Stroini" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Storozhevoi Class" } } }
-
-#ship = { name = "Tri Svyatitelya" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Tri Svititelia Class" } } }
+	  } }
 #ship = { name = "Rostislav" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Rotislav Class" } } }
 #ship = { name = "Panteleymon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kniaz Potemkin Class" } } }
 #ship = { name = "Evstafy" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = RUS } } }#KiS#version_name = "Ioann Zlatoust Class" } } }
@@ -2106,30 +2176,7 @@ ship = { name = "Stroini" definition = destroyer equipment = { destroyer_1900 = 
 #ship = { name = "Storozhevoy" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Storozhevoi Class" } } }
 #ship = { name = "Stroyny" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Storozhevoi Class" } } }
 		}
-	 navy = {
-		name = "Chernomorskaya Podvodnaya Flotiliya"
-		location=3686 # Sevastopol
-		base=3686 # Sevastopol
-ship = { name = "Delfin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS } } }
-ship = { name = "Feldmarshal Graf Sheremetev" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Kasatka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Makrel" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Nalim" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Okun" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Skat" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Kasatka Class" } } }
-ship = { name = "Beluga" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Losos" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Peskar" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Shchuka" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Som" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Sterlyad" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Sudak" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Holland Class" } } }
-ship = { name = "Kefal" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-ship = { name = "Sig" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = RUS version_name = "Lake Class" } } }
-
-		
-#ship = { name = "Delfin" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }
-#ship = { name = "Feldmarshal Graf Sheremetev" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kasatka Class" } } }
+	  } }
 #ship = { name = "Kasatka" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kasatka Class" } } }
 #ship = { name = "Makrel" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kasatka Class" } } }
 #ship = { name = "Nalim" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Kasatka Class" } } }
@@ -2145,43 +2192,7 @@ ship = { name = "Sig" definition = submarine equipment = { coastal_submarine_190
 #ship = { name = "Kefal" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Lake Class" } } }
 #ship = { name = "Sig" definition = coastal_submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Lake Class" } } }
 		}
-	 navy = {
-		name = "Sibirskaya Flotiliya"
-		location=957 # Vladivostok
-		base=957 # Vladivostok
-ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = RUS version_name = "Askold Class" } } }
-ship = { name = "Zhemchug" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = RUS version_name = "Zhemchug Class" } } }
-ship = { name = "Donskoi Kazak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Kazanets" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Sterehushchi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Strashni" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Turkmenetz-Stavropolski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Ukraina" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Vojskovoi" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Zabajkaletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Ukraina Class" } } }
-ship = { name = "Dobrovoletz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Emir Bukharski" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Finn" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Moskvityanin" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Emir Bukharski Class" } } }
-ship = { name = "Amuretz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "Gaidamak" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "Ussurietz" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "Vsadnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "Gaidamak Class" } } }
-ship = { name = "General Kondratenko" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Okhotnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Pogranichnik" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Sibirski Stryelok" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = RUS version_name = "General Kondratenko Class" } } }
-ship = { name = "Kapitan-Leitenant Baranov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Leitenant Pushchin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Leitenant Shestakov" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Leitenant Zatsarenni" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }
-ship = { name = "Novik" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS version_name = "Novik Class" } } }
-ship = { name = "Bespokoiny" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = RUS } } }
-ship = { name = "Gnevny" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = RUS } } }
-ship = { name = "Gromki" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = RUS } } }
-
-		
-#ship = { name = "Askold" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Askold Class" } } }
+	  } }
 #ship = { name = "Zhemchug" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = RUS } } }
 #ship = { name = "Donskoy Kazak" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Ukraina Class" } } }
 #ship = { name = "Kazanets" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = RUS } } }#KiS#version_name = "Ukraina Class" } } }

--- a/mod/thegreatwar/history/units/SIA_1910.txt
+++ b/mod/thegreatwar/history/units/SIA_1910.txt
@@ -31,6 +31,18 @@ division_template = {
 
 ###################################################################
 units = {
+
+fleet = {
+	name = "Royal Siamese Navy Fleet"
+	naval_base = 7408 # Phet Buri
+	task_force = {
+		name = "Royal Siamese Navy"
+		location = 7408 # Phet Buri
+		ship = { name = "Maha Chakri" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SIA } } }
+		ship = { name = "Sua Thaymon Chon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SIA } } }
+	}
+}
+
 	division= { 
 			name = "1. Thai Infantry Div."
 			location = 12122 # Phet Buri
@@ -53,14 +65,7 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0
 			}
-	 navy = {
-		name = "Royal Siamese Navy"
-		location = 7408 # Phet Buri
-		base =  7408 # Phet Buri
-ship = { name = "Maha Chakri" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SIA } } }
-ship = { name = "Sua Thaymon Chon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SIA } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/SIA_1914.txt
+++ b/mod/thegreatwar/history/units/SIA_1914.txt
@@ -32,6 +32,19 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Royal Siamese Navy Fleet"
+	naval_base = 7408 # Phet Buri
+	task_force = {
+		name = "Royal Siamese Navy"
+		location = 7408 # Phet Buri
+		ship = { name = "Maha Chakri" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SIA } } }
+		ship = { name = "Sua Thaymon Chon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SIA } } }
+		ship = { name = "Sua Khamron Sin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SIA } } }
+	}
+}
+
 	division= { 
 			name = "1. Thai Infantry Div."
 			location = 12122 # Phet Buri
@@ -54,15 +67,7 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0
 			}
-	 navy = {
-		name = "Royal Siamese Navy"
-		location = 7408 # Phet Buri
-		base =  7408 # Phet Buri
-ship = { name = "Maha Chakri" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SIA } } }
-ship = { name = "Sua Thaymon Chon" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SIA } } }
-ship = { name = "Sua Khamron Sin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SIA } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/SPR_1910.txt
+++ b/mod/thegreatwar/history/units/SPR_1910.txt
@@ -32,6 +32,29 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada Española Fleet"
+	naval_base = 1048 # Cádiz
+	task_force = {
+		name = "Armada Española"
+		location = 1048 # Cádiz
+		ship = { name = "Pelayo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Emparador Carlos V" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Princesa De Asturias" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
+		ship = { name = "Cataluña" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
+		ship = { name = "Infanta Isabel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Lepanto" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR version_name = "Reina Regente Class" } } }
+		ship = { name = "Rio De La Plata" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR version_name = "Rio De La Plata Class" } } }
+		ship = { name = "Estramadura" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR } } }
+		ship = { name = "Reina Regente" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR version_name = "Reina Regente II Class" } } }
+		ship = { name = "Audaz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Osado" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Prosperina" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Terror" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+	}
+}
+
 	division= { 
 			name = "1a División de Caballería"
 			location=3938 # Madrid
@@ -207,25 +230,7 @@ units = {
 			start_experience_factor=0
 			}
 			
-	navy = {
-		name = "Armada Española"
-		location = 1048 # Cádiz
-		base =  1048 # Cádiz
-ship = { name = "Pelayo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Emparador Carlos V" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Princesa De Asturias" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
-ship = { name = "Cataluña" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
-ship = { name = "Infanta Isabel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Lepanto" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR version_name = "Reina Regente Class" } } }
-ship = { name = "Rio De La Plata" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR version_name = "Rio De La Plata Class" } } }
-ship = { name = "Estramadura" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR } } }
-ship = { name = "Reina Regente" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR version_name = "Reina Regente II Class" } } }
-ship = { name = "Audaz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Osado" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Prosperina" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Terror" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-
-	}
+	
 }
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/SPR_1914.txt
+++ b/mod/thegreatwar/history/units/SPR_1914.txt
@@ -32,6 +32,31 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada Española Fleet"
+	naval_base = 1048 # Cádiz
+	task_force = {
+		name = "Armada Española"
+		location = 1048 # Cádiz
+		ship = { name = "Pelayo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "España" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = SPR } } }
+		ship = { name = "Emparador Carlos V" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Princesa De Asturias" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
+		ship = { name = "Cataluña" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
+		ship = { name = "Infanta Isabel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Rio De La Plata" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR version_name = "Rio De La Plata Class" } } }
+		ship = { name = "Estramadura" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR } } }
+		ship = { name = "Reina Regente" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR version_name = "Reina Regente II Class" } } }
+		ship = { name = "Audaz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Osado" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Prosperina" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Terror" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
+		ship = { name = "Bustamante" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = SPR } } }
+		ship = { name = "Villamil" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = SPR } } }
+	}
+}
+
 	division= { 
 			name = "1a División de Caballería"
 			location=3938 # Madrid
@@ -206,27 +231,7 @@ units = {
 			division_template="Infantry Brigade"
 			start_experience_factor=0
 			}
-	 navy = {
-		name = "Armada Española"
-		location = 1048 # Cádiz
-		base =  1048 # Cádiz
-ship = { name = "Pelayo" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "España" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = SPR } } }
-ship = { name = "Emparador Carlos V" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Princesa De Asturias" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
-ship = { name = "Cataluña" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = SPR version_name = "Cataluna Class" } } }
-ship = { name = "Infanta Isabel" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Rio De La Plata" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SPR version_name = "Rio De La Plata Class" } } }
-ship = { name = "Estramadura" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR } } }
-ship = { name = "Reina Regente" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = SPR version_name = "Reina Regente II Class" } } }
-ship = { name = "Audaz" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Osado" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Prosperina" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Terror" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = SPR } } }
-ship = { name = "Bustamante" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = SPR } } }
-ship = { name = "Villamil" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = SPR } } }
-
-		}
+	 
 	}
 air_wings = { 
 	165 = { # Madrid "Escuadrilla Expedicionaria Española"

--- a/mod/thegreatwar/history/units/SWE_1910.txt
+++ b/mod/thegreatwar/history/units/SWE_1910.txt
@@ -32,6 +32,45 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Svenska Flottan Fleet"
+	naval_base = 11215 # Karlskrona
+	task_force = {
+		name = "Svenska Flottan"
+		location = 11215 # Karlskrona
+		ship = { name = "HMS Svea" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Göta" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Thule" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Oden" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
+		ship = { name = "HMS Thor" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
+		ship = { name = "HMS Niord" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
+		ship = { name = "HMS Dristigheten" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Dristigheten Class" } } }
+		ship = { name = "HMS Äran" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Wasa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Tapperheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Manligheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Oscar II" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE version_name = "Oscar II Class" } } }
+		ship = { name = "HMS Fylgia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Örnen" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Claes Horn" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Jacob Bagge" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Psilander" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Claes Uggla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Mode" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Magne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Magne Class" } } }
+		ship = { name = "HMS Wale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Wale Class" } } }
+		ship = { name = "HMS Ragnar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Sigurd" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Vidar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Hajen" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Hvalen" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
+		ship = { name = "HMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
+		ship = { name = "HMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
+	}
+}
+
 	division= { 
 			name = "1:a Arméfördelningen"
 			location=383 # Göteborg
@@ -86,40 +125,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Svenska Flottan"
-		location=11215 # Karlskrona
-		base=11215 # Karlskrona
-ship = { name = "HMS Svea" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Göta" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Thule" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Oden" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
-ship = { name = "HMS Thor" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
-ship = { name = "HMS Niord" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
-ship = { name = "HMS Dristigheten" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Dristigheten Class" } } }
-ship = { name = "HMS Äran" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Wasa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Tapperheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Manligheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Oscar II" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE version_name = "Oscar II Class" } } }
-ship = { name = "HMS Fylgia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Örnen" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Claes Horn" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Jacob Bagge" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Psilander" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Claes Uggla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Mode" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Magne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Magne Class" } } }
-ship = { name = "HMS Wale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Wale Class" } } }
-ship = { name = "HMS Ragnar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Sigurd" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Vidar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Hajen" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Hvalen" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
-ship = { name = "HMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
-ship = { name = "HMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/SWE_1914.txt
+++ b/mod/thegreatwar/history/units/SWE_1914.txt
@@ -32,6 +32,47 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Svenska Flottan Fleet"
+	naval_base = 11215 # Karlskrona
+	task_force = {
+		name = "Svenska Flottan"
+		location = 11215 # Karlskrona
+		ship = { name = "HMS Svea" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Göta" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Thule" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Oden" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
+		ship = { name = "HMS Thor" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
+		ship = { name = "HMS Niord" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
+		ship = { name = "HMS Dristigheten" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Dristigheten Class" } } }
+		ship = { name = "HMS Äran" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Wasa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Tapperheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Manligheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Oscar II" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE version_name = "Oscar II Class" } } }
+		ship = { name = "HMS Fylgia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Örnen" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Claes Horn" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Jacob Bagge" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Psilander" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Claes Uggla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Mode" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Magne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Magne Class" } } }
+		ship = { name = "HMS Wale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Wale Class" } } }
+		ship = { name = "HMS Ragnar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Sigurd" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Vidar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Hugin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE version_name = "Hugin Class" } } }
+		ship = { name = "HMS Munin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE version_name = "Hugin Class" } } }
+		ship = { name = "HMS Hajen" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS Hvalen" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE } } }
+		ship = { name = "HMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
+		ship = { name = "HMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
+		ship = { name = "HMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
+	}
+}
+
 	division= { 
 			name = "1:a Arméfördelningen"
 			location=383 # Göteborg
@@ -86,43 +127,7 @@ units = {
 			division_template="Infantry Division"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Svenska Flottan"
-		location=11215 # Karlskrona
-		base=11215 # Karlskrona
-ship = { name = "HMS Svea" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Göta" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Thule" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Oden" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
-ship = { name = "HMS Thor" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
-ship = { name = "HMS Niord" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Oden Class" } } }
-ship = { name = "HMS Dristigheten" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = SWE version_name = "Dristigheten Class" } } }
-ship = { name = "HMS Äran" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Wasa" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Tapperheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Manligheten" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Oscar II" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = SWE version_name = "Oscar II Class" } } }
-ship = { name = "HMS Fylgia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Örnen" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Claes Horn" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Jacob Bagge" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Psilander" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Claes Uggla" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Mode" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Magne" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Magne Class" } } }
-ship = { name = "HMS Wale" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = SWE version_name = "Wale Class" } } }
-ship = { name = "HMS Ragnar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Sigurd" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Vidar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Hugin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE version_name = "Hugin Class" } } }
-ship = { name = "HMS Munin" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = SWE version_name = "Hugin Class" } } }
-ship = { name = "HMS Hajen" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS Hvalen" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE } } }
-ship = { name = "HMS U2" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
-ship = { name = "HMS U3" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
-ship = { name = "HMS U4" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = SWE version_name = "U2 Class" } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/TUR_1910.txt
+++ b/mod/thegreatwar/history/units/TUR_1910.txt
@@ -41,6 +41,54 @@ division_template = {
 # 7 Corps x 3 divisions + 5 divisions @10,300/division of infantry = 267800, goal of ~270,000 active in 1909
 # 13 cavaly brigades @ 4300/brigade of cavalry = 55900, goal of 55/56K historically
 units = {
+
+fleet = {
+	name = "Osmanli Donanmasi Fleet"
+	naval_base = 4112 # Smyrna
+	task_force = {
+		name = "Osmanli Donanmasi"
+		location = 4112 # Smyrna
+		ships "Barbaros Hayreddin", "Turgut Reis", acquired 12 September 1910, excluded for 1910 scenario
+		# 1 cruiser "Midili" (former SMS Breslau) acquired 16 August 1914, excluded for 1910 scenario
+		# 2 "torpedo cruisers" (aka destroyers) "Peyk-i Şevket", "Berk-i Şevket"  both available 1910
+		# 1 coastal defence ship "Mesûdiye" - class as really old cruiser, both available 1910
+		# 2 Protected Cruisers "Hamidiye", "Mecidiye", both available 1910
+		# 8 destroyers "Basra", "Samsun", "Taşoz", "Yarhisar",  "Gayret-i Vatâniye", "Yâdigâr-ı Millet", "Muâvenet-i Millîye" , "Nümûne-i Hamiyet", some available 1910, assume all?
+		# 8 "torpedo boats" aka small destroyers, "Draç","Kütahya","Mûsul","Akhisar","Sultanhisar","Demirhisar","Sivrihisar","Hamidâbad"
+		# some minelayers, also excluded
+		
+		#ship = { name = "Mesûdiye" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "Mesûdiye" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = TUR } } }
+		ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR } } }
+		ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR version_name = "Medjidieh Class" } } }
+		ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Berk-i Şevket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "Peyk-i Şevket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "İclaliye" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "İclaliye Class" } } }
+		ship = { name = "Feth-i Bülend" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Feth-i Bülend Class" } } }
+		ship = { name = "Avni Illah" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Avni Illah Class" } } }
+		ship = { name = "Muin-i-Zaffer" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Avni Illah Class" } } }
+		ship = { name = "Peleng-i Derya" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
+	}
+}
+
 	division = {
 	    name = "1. Piyade Tümeni 'Harbiye'"
 	    location = 9833# Istanbul
@@ -453,58 +501,7 @@ units = {
 	#    division_template = "Süvari Tugayı"
 	#    start_experience_factor = 0
 	#}
-	navy = {
-		name = "Osmanli Donanmasi"
-		location = 4112 # Smyrna
-		base =  4112 # Smyrna
-		 
-		# 1914 strengths: 
-		# 1 modern battlecruiser "Yavûz Sultân Selîm" former SMS Goeben, acquired 29 October 1914, excluded for 1910 scenario
-		# 2 pre-dreadnought battleships "Barbaros Hayreddin", "Turgut Reis", acquired 12 September 1910, excluded for 1910 scenario
-		# 1 cruiser "Midili" (former SMS Breslau) acquired 16 August 1914, excluded for 1910 scenario
-		# 2 "torpedo cruisers" (aka destroyers) "Peyk-i Şevket", "Berk-i Şevket"  both available 1910
-		# 1 coastal defence ship "Mesûdiye" - class as really old cruiser, both available 1910
-		# 2 Protected Cruisers "Hamidiye", "Mecidiye", both available 1910
-		# 8 destroyers "Basra", "Samsun", "Taşoz", "Yarhisar",  "Gayret-i Vatâniye", "Yâdigâr-ı Millet", "Muâvenet-i Millîye" , "Nümûne-i Hamiyet", some available 1910, assume all?
-		# 8 "torpedo boats" aka small destroyers, "Draç","Kütahya","Mûsul","Akhisar","Sultanhisar","Demirhisar","Sivrihisar","Hamidâbad"
-		# some minelayers, also excluded
-		
-		#ship = { name = "Mesûdiye" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
-ship = { name = "Mesûdiye" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = TUR } } }
-		
-		#ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR version_name = "Medjidieh Class" } } }
-		
-		#ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-		#ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-		#ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-		#ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-
-ship = { name = "Berk-i Şevket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = TUR } } }	
-ship = { name = "Peyk-i Şevket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = TUR } } }
-ship = { name = "İclaliye" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "İclaliye Class" } } }
-ship = { name = "Feth-i Bülend" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Feth-i Bülend Class" } } }
-ship = { name = "Avni Illah" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Avni Illah Class" } } }
-ship = { name = "Muin-i-Zaffer" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Avni Illah Class" } } }
-ship = { name = "Peleng-i Derya" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
-
-		
 	
-	}
 }
 air_wings = {}
 instant_effect = {

--- a/mod/thegreatwar/history/units/TUR_1914.txt
+++ b/mod/thegreatwar/history/units/TUR_1914.txt
@@ -45,6 +45,55 @@ division_template = {
 # 4th Army @ Baghdad: 4 Divisions of infantry
 # Placed in game: 33 Infantry Divisions, 5 Gendarmerie Regiments (, 4 Cavalry Brigades
 units = {
+
+fleet = {
+	name = "Osmanli Donanmasi Fleet"
+	naval_base = 4112 # Smyrna
+	task_force = {
+		name = "Osmanli Donanmasi"
+		location = 4112 # Smyrna
+		ships "Barbaros Hayreddin", "Turgut Reis", acquired 12 September 1910
+		# 1 cruiser "Midili" (former SMS Breslau) acquired 16 August 1914, excluded for 1914 scenario
+		# 2 "torpedo cruisers" (aka destroyers) "Peyk-i Şevket", "Berk-i Şevket"  both available 1910
+		# 1 coastal defence ship "Mesûdiye" - class as really old cruiser, both available 1910
+		# 2 Protected Cruisers "Hamidiye", "Mecidiye", both available 1910
+		# 8 destroyers "Basra", "Samsun", "Taşoz", "Yarhisar",  "Gayret-i Vatâniye", "Yâdigâr-ı Millet", "Muâvenet-i Millîye" , "Nümûne-i Hamiyet", some available 1910, assume all?
+		# 8 "torpedo boats" aka small destroyers, "Draç","Kütahya","Mûsul","Akhisar","Sultanhisar","Demirhisar","Sivrihisar","Hamidâbad"
+		# some minelayers, also excluded
+		
+		#ship = { name = "Barbaros Hayreddin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "Turgut Reis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "Hayreddin Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "Turgut Reis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "Mesûdiye" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "Mesûdiye" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = TUR } } }
+		ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR } } }
+		ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR version_name = "Medjidieh Class" } } }
+		ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
+		ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
+		ship = { name = "Peyk-i Şevket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = TUR } } }
+		ship = { name = "İclaliye" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "İclaliye Class" } } }
+		ship = { name = "Muin-i-Zaffer" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Avni Illah Class" } } }
+		ship = { name = "Peleng-i Derya" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
+	}
+}
+
 	division= { 
 			name = "1. Piyade Tümeni 'Harbiye'"
 			location=9833 # Istanbul
@@ -366,63 +415,7 @@ units = {
 			# start_equipment_factor = 0.3 
 			# start_manpower_factor = 0.3
 			}
-	 navy = {
-		name = "Osmanli Donanmasi"
-		location = 4112 # Smyrna
-		base =  4112 # Smyrna
-		# 1914 strengths: 
-		# 1 modern battlecruiser "Yavûz Sultân Selîm" former SMS Goeben, acquired 29 October 1914, excluded for 1914 scenario
-		# 2 pre-dreadnought battleships "Barbaros Hayreddin", "Turgut Reis", acquired 12 September 1910
-		# 1 cruiser "Midili" (former SMS Breslau) acquired 16 August 1914, excluded for 1914 scenario
-		# 2 "torpedo cruisers" (aka destroyers) "Peyk-i Şevket", "Berk-i Şevket"  both available 1910
-		# 1 coastal defence ship "Mesûdiye" - class as really old cruiser, both available 1910
-		# 2 Protected Cruisers "Hamidiye", "Mecidiye", both available 1910
-		# 8 destroyers "Basra", "Samsun", "Taşoz", "Yarhisar",  "Gayret-i Vatâniye", "Yâdigâr-ı Millet", "Muâvenet-i Millîye" , "Nümûne-i Hamiyet", some available 1910, assume all?
-		# 8 "torpedo boats" aka small destroyers, "Draç","Kütahya","Mûsul","Akhisar","Sultanhisar","Demirhisar","Sivrihisar","Hamidâbad"
-		# some minelayers, also excluded
-		
-		#ship = { name = "Barbaros Hayreddin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Turgut Reis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
-ship = { name = "Hayreddin Barbarossa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
-ship = { name = "Turgut Reis" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = TUR } } }
-
-		
-		#ship = { name = "Mesûdiye" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
-ship = { name = "Mesûdiye" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = TUR } } }
-		
-		#ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Hamidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Mecidiye" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = TUR version_name = "Medjidieh Class" } } }
-		
-		#ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Basra" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Samsun" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Taşoz" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Yarhisar" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-		#ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Gayret-i Vatâniye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-		#ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Yâdigâr-ı Millet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-		#ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Muâvenet-i Millîye" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-		#ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR } } }
-ship = { name = "Nümûne-i Hamiyet" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = TUR version_name = "S165 Class" } } }
-
-ship = { name = "Peyk-i Şevket" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = TUR } } }
-ship = { name = "İclaliye" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "İclaliye Class" } } }
-
-ship = { name = "Muin-i-Zaffer" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = TUR version_name = "Avni Illah Class" } } }
-ship = { name = "Peleng-i Derya" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = TUR } } }
-		
-		
-		
-		
-	
-	}
+	 
 }
 air_wings = {
 

--- a/mod/thegreatwar/history/units/URG_1910.txt
+++ b/mod/thegreatwar/history/units/URG_1910.txt
@@ -33,19 +33,24 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada de Uruguay Fleet"
+	naval_base = 10362 # Montevideo
+	task_force = {
+		name = "Armada de Uruguay"
+		location = 10362 # Montevideo
+		ship = { name = "Montevido" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = URG } } }
+	}
+}
+
 	division= { 
 			name = "4a Brigada de Inf. 'Don Claudio'"
 			location=10362 # Montevideo
 			division_template="Infantry Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Armada de Uruguay"
-		location=10362 # Montevideo
-		base=10362 # Montevideo
-ship = { name = "Montevido" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = URG } } }
-
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/URG_1914.txt
+++ b/mod/thegreatwar/history/units/URG_1914.txt
@@ -33,18 +33,24 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Armada de Uruguay Fleet"
+	naval_base = 10362 # Montevideo
+	task_force = {
+		name = "Armada de Uruguay"
+		location = 10362 # Montevideo
+		ship = { name = "Montevido" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = URG } } }
+	}
+}
+
 	division= { 
 			name = "4a Brigada de Inf. 'Don Claudio'"
 			location=10362 # Montevideo
 			division_template="Infantry Division"
 			start_experience_factor=0.1
 			}
-	 navy = {
-		name = "Armada de Uruguay"
-		location=10362 # Montevideo
-		base=10362 # Montevideo
-ship = { name = "Montevido" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = URG } } }
-		}
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/USA_1910.txt
+++ b/mod/thegreatwar/history/units/USA_1910.txt
@@ -40,6 +40,165 @@ division_template = {
 
 	
 units = {
+
+fleet = {
+	name = "Submarine Flotilla Fleet"
+	naval_base = 7552 # New Orleans
+	task_force = {
+		name = "Submarine Flotilla"
+		location = 7552 # New Orleans
+		ship = { name = "USS Holland" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Plunger" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Adder" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Grampus" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Moccasin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Pike" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Porpoise" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Shark" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Viper" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
+		ship = { name = "USS Cuttlefish" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
+		ship = { name = "USS Tarantula" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
+		ship = { name = "USS Octopus" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Stingray" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Tarpon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Bonita" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Snapper" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Narwhal" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Grayling" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Salmon" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
+	}
+	task_force = {
+		name = "Caribbean Squadron"
+		location = 7552 # New Orleans
+		ship = { name = "USS Virginia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS New Jersey" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Rhode Island" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Connecticut" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Kansas" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS Michigan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
+		ship = { name = "USS Chester" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Birmingham" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Salem" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
+	}
+}
+
+fleet = {
+	name = "Pacific Fleet Fleet"
+	naval_base = 9814 # Los Angeles
+	task_force = {
+		name = "Pacific Fleet"
+		location = 9814 # Los Angeles
+		ship = { name = "USS California" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS South Dakota" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Tennessee" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS Washington" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS West Virginia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Colorado" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS St. Louis" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
+		ship = { name = "USS Milwaukee" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
+		ship = { name = "USS Charleston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
+	}
+}
+
+fleet = {
+	name = "Asiatic Fleet Fleet"
+	naval_base = 10265 # Manila
+	task_force = {
+		name = "Asiatic Fleet"
+		location = 10265 # Manila
+		ship = { name = "USS Saratoga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Pittsburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Denver" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+	}
+}
+
+fleet = {
+	name = "Atlantic Fleet Fleet"
+	naval_base = 788 # Norfolk
+	task_force = {
+		name = "Atlantic Fleet"
+		location = 788 # Norfolk
+		ship = { name = "USS Delaware" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS North Dakota" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Maine" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
+		ship = { name = "USS Missouri" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
+		ship = { name = "USS Ohio" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
+		ship = { name = "USS Nebraska" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Georgia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Louisiana" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Vermont" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS Minnesota" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS South Carolina" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
+		ship = { name = "USS New Hampshire" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS North Carolina" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS Montana" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS Maryland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Des Moines" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Chattanooga" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Galveston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Tacoma" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Cleveland" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Cincinnati" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
+		ship = { name = "USS Atlanta" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Boston" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Chicago" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Chicago Class" } } }
+		ship = { name = "USS Newark" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Newark Class" } } }
+		ship = { name = "USS Baltimore" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Baltimore Class" } } }
+		ship = { name = "USS Philadelphia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Philadelphia Class" } } }
+		ship = { name = "USS San Francisco" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "San Francisco Class" } } }
+		ship = { name = "USS Olympia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Olympia Class" } } }
+		ship = { name = "USS Raleigh" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
+		ship = { name = "USS Montgomery" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
+		ship = { name = "USS New Orleans" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
+		ship = { name = "USS Albany" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
+		ship = { name = "USS Bainbridge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Barry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Chauncey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Dale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Decatur" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Hopkins" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
+		ship = { name = "USS Hull" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
+		ship = { name = "USS Lawrence" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
+		ship = { name = "USS Macdonough" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
+		ship = { name = "USS Paul Jones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
+		ship = { name = "USS Perry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
+		ship = { name = "USS Preble" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
+		ship = { name = "USS Stewart" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Stewart Class" } } }
+		ship = { name = "USS Truxtun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Whipple" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Worden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Smith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Lamson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Preston" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Flusser" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Reid" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Paulding" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Roe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Terry" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Mayrant" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+	}
+	task_force = {
+		name = "Atlantic Reserve Fleet"
+		location = 788 # Norfolk
+		ship = { name = "USS Texas" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Indiana" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
+		ship = { name = "USS Massachusetts" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
+		ship = { name = "USS Oregon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
+		ship = { name = "USS Iowa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Iowa Class" } } }
+		ship = { name = "USS Kearsarge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
+		ship = { name = "USS Kentucky" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
+		ship = { name = "USS Illinois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
+		ship = { name = "USS Alabama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
+		ship = { name = "USS Wisconsin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
+		ship = { name = "USS Mississippi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
+		ship = { name = "USS Idaho" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
+		ship = { name = "USS Brooklyn" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA version_name = "Brooklyn Class" } } }
+		ship = { name = "USS Marblehead" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
+		ship = { name = "USS Colombia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
+		ship = { name = "USS Minneapolis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st Infantry Division"
 			location=3878 # New York
@@ -310,156 +469,12 @@ units = {
 			division_template="National Guard"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Atlantic Fleet"
-		location=788 # Norfolk
-		base=788 # Norfolk
-ship = { name = "USS Delaware" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS North Dakota" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Maine" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
-ship = { name = "USS Missouri" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
-ship = { name = "USS Ohio" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
-ship = { name = "USS Nebraska" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Georgia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Louisiana" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Vermont" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS Minnesota" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS South Carolina" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
-ship = { name = "USS New Hampshire" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS North Carolina" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS Montana" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS Maryland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Des Moines" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Chattanooga" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Galveston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Tacoma" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Cleveland" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Cincinnati" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
-ship = { name = "USS Atlanta" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Boston" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Chicago" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Chicago Class" } } }
-ship = { name = "USS Newark" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Newark Class" } } }
-ship = { name = "USS Baltimore" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Baltimore Class" } } }
-ship = { name = "USS Philadelphia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Philadelphia Class" } } }
-ship = { name = "USS San Francisco" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "San Francisco Class" } } }
-ship = { name = "USS Olympia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Olympia Class" } } }
-ship = { name = "USS Raleigh" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
-ship = { name = "USS Montgomery" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
-ship = { name = "USS New Orleans" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
-ship = { name = "USS Albany" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
-ship = { name = "USS Bainbridge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Barry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Chauncey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Dale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Decatur" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Hopkins" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
-ship = { name = "USS Hull" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
-ship = { name = "USS Lawrence" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
-ship = { name = "USS Macdonough" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
-ship = { name = "USS Paul Jones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
-ship = { name = "USS Perry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
-ship = { name = "USS Preble" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
-ship = { name = "USS Stewart" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Stewart Class" } } }
-ship = { name = "USS Truxtun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Whipple" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Worden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Smith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Lamson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Preston" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Flusser" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Reid" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Paulding" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Roe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Terry" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Mayrant" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-
-		}
-	 navy = {
-		name = "Submarine Flotilla"
-		location=7552 # New Orleans
-		base=7552 # New Orleans
-ship = { name = "USS Holland" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Plunger" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Adder" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Grampus" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Moccasin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Pike" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Porpoise" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Shark" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Viper" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
-ship = { name = "USS Cuttlefish" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
-ship = { name = "USS Tarantula" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
-ship = { name = "USS Octopus" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Stingray" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Tarpon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Bonita" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Snapper" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Narwhal" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Grayling" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Salmon" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
-
-		}
-	 navy = {
-		name = "Atlantic Reserve Fleet"
-		location=788 # Norfolk
-		base=788 # Norfolk
-ship = { name = "USS Texas" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Indiana" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
-ship = { name = "USS Massachusetts" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
-ship = { name = "USS Oregon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
-ship = { name = "USS Iowa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Iowa Class" } } }
-ship = { name = "USS Kearsarge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
-ship = { name = "USS Kentucky" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
-ship = { name = "USS Illinois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
-ship = { name = "USS Alabama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
-ship = { name = "USS Wisconsin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
-ship = { name = "USS Mississippi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
-ship = { name = "USS Idaho" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
-ship = { name = "USS Brooklyn" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA version_name = "Brooklyn Class" } } }
-ship = { name = "USS Marblehead" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
-ship = { name = "USS Colombia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
-ship = { name = "USS Minneapolis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
-
-		}
-	 navy = {
-		name = "Caribbean Squadron"
-		location=7552 # New Orleans
-		base=7552 # New Orleans
-ship = { name = "USS Virginia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS New Jersey" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Rhode Island" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Connecticut" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Kansas" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS Michigan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
-ship = { name = "USS Chester" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Birmingham" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Salem" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
-
-		}
-	 navy = {
-		name = "Pacific Fleet"
-		location=9814 # Los Angeles
-		base=9814 # Los Angeles
-ship = { name = "USS California" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS South Dakota" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Tennessee" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS Washington" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS West Virginia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Colorado" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS St. Louis" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
-ship = { name = "USS Milwaukee" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
-ship = { name = "USS Charleston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
-
-		}
-	 navy = {
-		name = "Asiatic Fleet"
-		location=10265 # Manila
-		base=10265 # Manila
-ship = { name = "USS Saratoga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Pittsburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Denver" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-
-		}
+	 
+	 
+	 
+	 
+	 
+	 
 	}
 air_wings = { 
 	}

--- a/mod/thegreatwar/history/units/USA_1914.txt
+++ b/mod/thegreatwar/history/units/USA_1914.txt
@@ -38,6 +38,206 @@ division_template = {
 ###################################################################
 
 units = {
+
+fleet = {
+	name = "Pacific Fleet Fleet"
+	naval_base = 9814 # Los Angeles
+	task_force = {
+		name = "Pacific Fleet"
+		location = 9814 # Los Angeles
+		ship = { name = "USS California" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS South Dakota" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Tennessee" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS Washington" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS West Virginia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Colorado" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS St. Louis" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
+		ship = { name = "USS Milwaukee" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
+		ship = { name = "USS Charleston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
+		ship = { name = "USS Hopkins" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
+		ship = { name = "USS Hull" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
+		ship = { name = "USS Lawrence" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
+		ship = { name = "USS Macdonough" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
+		ship = { name = "USS Paul Jones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
+		ship = { name = "USS Perry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
+		ship = { name = "USS Preble" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
+		ship = { name = "USS Stewart" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Stewart Class" } } }
+	}
+}
+
+fleet = {
+	name = "Asiatic Fleet Fleet"
+	naval_base = 10265 # Manila
+	task_force = {
+		name = "Asiatic Fleet"
+		location = 10265 # Manila
+		ship = { name = "USS Saratoga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Pittsburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Denver" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Bainbridge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Barry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Chauncey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Dale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Decatur" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
+	}
+}
+
+fleet = {
+	name = "Atlantic Fleet Fleet"
+	naval_base = 788 # Norfolk
+	task_force = {
+		name = "Atlantic Fleet"
+		location = 788 # Norfolk
+		ship = { name = "USS Delaware" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS North Dakota" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Florida" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA version_name = "Florida Class" } } }
+		ship = { name = "USS Utah" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA version_name = "Florida Class" } } }
+		ship = { name = "USS Wyoming" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Arkansas" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Maine" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
+		ship = { name = "USS Missouri" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
+		ship = { name = "USS Ohio" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
+		ship = { name = "USS Nebraska" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Georgia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Louisiana" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Vermont" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS Minnesota" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS South Carolina" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
+		ship = { name = "USS New Hampshire" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS North Carolina" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS Montana" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
+		ship = { name = "USS Des Moines" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Chattanooga" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Galveston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Tacoma" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Cleveland" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Maryland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Boston" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Chicago" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Chicago Class" } } }
+		ship = { name = "USS Newark" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Newark Class" } } }
+		ship = { name = "USS Baltimore" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Baltimore Class" } } }
+		ship = { name = "USS Philadelphia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Philadelphia Class" } } }
+		ship = { name = "USS San Francisco" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "San Francisco Class" } } }
+		ship = { name = "USS Olympia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Olympia Class" } } }
+		ship = { name = "USS Cincinnati" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
+		ship = { name = "USS Raleigh" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
+		ship = { name = "USS Montgomery" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
+		ship = { name = "USS Marblehead" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
+		ship = { name = "USS New Orleans" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
+		ship = { name = "USS Albany" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
+		ship = { name = "USS Paulding" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Drayton" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Roe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Terry" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Perkins" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Sterett" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS McCall" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Burrows" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Warrington" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Mayrant" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Monaghan" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Trippe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Walke" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Ammen" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Patterson" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Fanning" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Jarvis" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Henley" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Beale" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Jouett" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Jenkins" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
+		ship = { name = "USS Cassin" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Cummings" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Downes" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Duncan" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Aylwin" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Parker" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Benham" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Balch" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
+	}
+	task_force = {
+		name = "Atlantic Reserve Fleet"
+		location = 788 # Norfolk
+		ship = { name = "USS Indiana" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
+		ship = { name = "USS Massachusetts" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
+		ship = { name = "USS Oregon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
+		ship = { name = "USS Iowa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Iowa Class" } } }
+		ship = { name = "USS Kearsarge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
+		ship = { name = "USS Kentucky" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
+		ship = { name = "USS Illinois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
+		ship = { name = "USS Alabama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
+		ship = { name = "USS Wisconsin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
+		ship = { name = "USS Mississippi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
+		ship = { name = "USS Idaho" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
+		ship = { name = "USS Brooklyn" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA version_name = "Brooklyn Class" } } }
+		ship = { name = "USS Colombia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
+		ship = { name = "USS Minneapolis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
+	}
+}
+
+fleet = {
+	name = "Submarine Flotilla Fleet"
+	naval_base = 7552 # New Orleans
+	task_force = {
+		name = "Submarine Flotilla"
+		location = 7552 # New Orleans
+		ship = { name = "USS Plunger" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Adder" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Grampus" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Moccasin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Pike" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Porpoise" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Shark" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
+		ship = { name = "USS Viper" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
+		ship = { name = "USS Cuttlefish" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
+		ship = { name = "USS Tarantula" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
+		ship = { name = "USS Octopus" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Stingray" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Tarpon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Bonita" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Snapper" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Narwhal" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Grayling" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Salmon" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Skipjack" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "E Class" } } }
+		ship = { name = "USS Sturgeon" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "E Class" } } }
+		ship = { name = "USS Carp" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
+		ship = { name = "USS Barracuda" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
+		ship = { name = "USS Pickerel" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
+		ship = { name = "USS Skate" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
+		ship = { name = "USS Seal" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
+		ship = { name = "USS Thresher" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
+		ship = { name = "USS Tuna" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
+		ship = { name = "USS Turbot" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
+		ship = { name = "USS Seawolf" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "H Class" } } }
+		ship = { name = "USS Nautilus" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "H Class" } } }
+		ship = { name = "USS Garfish" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "H Class" } } }
+		ship = { name = "USS Haddock" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "K Class" } } }
+		ship = { name = "USS Cachalot" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "K Class" } } }
+	}
+	task_force = {
+		name = "Caribbean Squadron"
+		location = 7552 # New Orleans
+		ship = { name = "USS Virginia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS New Jersey" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Rhode Island" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
+		ship = { name = "USS Connecticut" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Kansas" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
+		ship = { name = "USS Michigan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
+		ship = { name = "USS Chester" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Birmingham" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Salem" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Truxtun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Whipple" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Worden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
+		ship = { name = "USS Smith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Lamson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Preston" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Flusser" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+		ship = { name = "USS Reid" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
+	}
+}
+
 	division= { 
 			name = "1st Infantry Division"
 			location=3878 # New York
@@ -356,197 +556,12 @@ units = {
 			division_template="National Guard"
 			start_experience_factor=0.05
 			}
-	 navy = {
-		name = "Atlantic Fleet"
-		location=788 # Norfolk
-		base=788 # Norfolk
-ship = { name = "USS Delaware" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS North Dakota" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Florida" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA version_name = "Florida Class" } } }
-ship = { name = "USS Utah" definition = battleship equipment = { battleship_1906 = { amount = 1 owner = USA version_name = "Florida Class" } } }
-ship = { name = "USS Wyoming" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Arkansas" definition = battleship equipment = { battleship_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Maine" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
-ship = { name = "USS Missouri" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
-ship = { name = "USS Ohio" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Maine Class" } } }
-ship = { name = "USS Nebraska" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Georgia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Louisiana" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Vermont" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS Minnesota" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS South Carolina" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
-ship = { name = "USS New Hampshire" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS North Carolina" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS Montana" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS Des Moines" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Chattanooga" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Galveston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Tacoma" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Cleveland" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Maryland" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Boston" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Chicago" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Chicago Class" } } }
-ship = { name = "USS Newark" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Newark Class" } } }
-ship = { name = "USS Baltimore" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Baltimore Class" } } }
-ship = { name = "USS Philadelphia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Philadelphia Class" } } }
-ship = { name = "USS San Francisco" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "San Francisco Class" } } }
-ship = { name = "USS Olympia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Olympia Class" } } }
-ship = { name = "USS Cincinnati" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
-ship = { name = "USS Raleigh" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Cincinnati Class" } } }
-ship = { name = "USS Montgomery" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
-ship = { name = "USS Marblehead" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Montgomery Class" } } }
-ship = { name = "USS New Orleans" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
-ship = { name = "USS Albany" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "New Orleans Class" } } }
-ship = { name = "USS Paulding" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Drayton" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Roe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Terry" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Perkins" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Sterett" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS McCall" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Burrows" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Warrington" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Mayrant" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Monaghan" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Trippe" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Walke" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Ammen" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Patterson" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Fanning" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Jarvis" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Henley" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Beale" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Jouett" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Jenkins" definition = destroyer equipment = { destroyer_1906 = { amount = 1 owner = USA version_name = "Monaghan Class" } } }
-ship = { name = "USS Cassin" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Cummings" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Downes" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Duncan" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Aylwin" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Parker" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Benham" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Balch" definition = destroyer equipment = { destroyer_1910 = { amount = 1 owner = USA } } }
-
-		}
-	 navy = {
-		name = "Submarine Flotilla"
-		location=7552 # New Orleans
-		base=7552 # New Orleans
-ship = { name = "USS Plunger" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Adder" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Grampus" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Moccasin" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Pike" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Porpoise" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Shark" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "A Class" } } }
-ship = { name = "USS Viper" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
-ship = { name = "USS Cuttlefish" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
-ship = { name = "USS Tarantula" definition = submarine equipment = { coastal_submarine_1900 = { amount = 1 owner = USA version_name = "B Class" } } }
-ship = { name = "USS Octopus" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Stingray" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Tarpon" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Bonita" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Snapper" definition = submarine equipment = { coastal_submarine_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Narwhal" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Grayling" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Salmon" definition = submarine equipment = { coastal_submarine_1910 = { amount = 1 owner = USA } } }
-ship = { name = "USS Skipjack" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "E Class" } } }
-ship = { name = "USS Sturgeon" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "E Class" } } }
-ship = { name = "USS Carp" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
-ship = { name = "USS Barracuda" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
-ship = { name = "USS Pickerel" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
-ship = { name = "USS Skate" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "F Class" } } }
-ship = { name = "USS Seal" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
-ship = { name = "USS Thresher" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
-ship = { name = "USS Tuna" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
-ship = { name = "USS Turbot" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "G Class" } } }
-ship = { name = "USS Seawolf" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "H Class" } } }
-ship = { name = "USS Nautilus" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "H Class" } } }
-ship = { name = "USS Garfish" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "H Class" } } }
-ship = { name = "USS Haddock" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "K Class" } } }
-ship = { name = "USS Cachalot" definition = submarine equipment = { submarine_1914 = { amount = 1 owner = USA version_name = "K Class" } } }
-
-		}
-	 navy = {
-		name = "Atlantic Reserve Fleet"
-		location=788 # Norfolk
-		base=788 # Norfolk
-ship = { name = "USS Indiana" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
-ship = { name = "USS Massachusetts" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
-ship = { name = "USS Oregon" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Indiana Class" } } }
-ship = { name = "USS Iowa" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Iowa Class" } } }
-ship = { name = "USS Kearsarge" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
-ship = { name = "USS Kentucky" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Kearsarge Class" } } }
-ship = { name = "USS Illinois" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
-ship = { name = "USS Alabama" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
-ship = { name = "USS Wisconsin" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Illinois Class" } } }
-ship = { name = "USS Mississippi" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
-ship = { name = "USS Idaho" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Mississippi Class" } } }
-ship = { name = "USS Brooklyn" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA version_name = "Brooklyn Class" } } }
-ship = { name = "USS Colombia" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
-ship = { name = "USS Minneapolis" definition = light_cruiser equipment = { light_cruiser_1890 = { amount = 1 owner = USA version_name = "Colombia Class" } } }
-
-		}
-	 navy = {
-		name = "Caribbean Squadron"
-		location=7552 # New Orleans
-		base=7552 # New Orleans
-ship = { name = "USS Virginia" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS New Jersey" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Rhode Island" definition = battleship equipment = { battleship_1890 = { amount = 1 owner = USA version_name = "Virginia Class" } } }
-ship = { name = "USS Connecticut" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Kansas" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "Vermont Class" } } }
-ship = { name = "USS Michigan" definition = battleship equipment = { battleship_1900 = { amount = 1 owner = USA version_name = "South Carolina Class" } } }
-ship = { name = "USS Chester" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Birmingham" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Salem" definition = light_cruiser equipment = { light_cruiser_1906 = { amount = 1 owner = USA } } }
-ship = { name = "USS Truxtun" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Whipple" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Worden" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Smith" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Lamson" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Preston" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Flusser" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-ship = { name = "USS Reid" definition = destroyer equipment = { destroyer_1900 = { amount = 1 owner = USA version_name = "Smith Class" } } }
-
-		}
-	 navy = {
-		name = "Pacific Fleet"
-		location=9814 # Los Angeles
-		base=9814 # Los Angeles
-ship = { name = "USS California" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS South Dakota" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Tennessee" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS Washington" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA version_name = "Tennessee Class" } } }
-ship = { name = "USS West Virginia" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Colorado" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS St. Louis" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
-ship = { name = "USS Milwaukee" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
-ship = { name = "USS Charleston" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA version_name = "St. Louis Class" } } }
-ship = { name = "USS Hopkins" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
-ship = { name = "USS Hull" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Hopkins Class" } } }
-ship = { name = "USS Lawrence" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
-ship = { name = "USS Macdonough" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Lawrence Class" } } }
-ship = { name = "USS Paul Jones" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
-ship = { name = "USS Perry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
-ship = { name = "USS Preble" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Paul Jones Class" } } }
-ship = { name = "USS Stewart" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA version_name = "Stewart Class" } } }
-
-		}
-	 navy = {
-		name = "Asiatic Fleet"
-		location=10265 # Manila
-		base=10265 # Manila
-ship = { name = "USS Saratoga" definition = heavy_cruiser equipment = { heavy_cruiser_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Pittsburgh" definition = heavy_cruiser equipment = { heavy_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Denver" definition = light_cruiser equipment = { light_cruiser_1900 = { amount = 1 owner = USA } } }
-ship = { name = "USS Bainbridge" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Barry" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Chauncey" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Dale" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-ship = { name = "USS Decatur" definition = destroyer equipment = { destroyer_1890 = { amount = 1 owner = USA } } }
-
-		}
+	 
+	 
+	 
+	 
+	 
+	 
 		}
 
 	air_wings = { 


### PR DESCRIPTION
### **Problem**
See https://github.com/Wolferos/Hearts-of-Iron-IV-The-Great-War/pull/203 for more details. Ship names don't appear and ships aren't organized into fleets.

### **Solution**
Update them all with a tool so I keep my sanity.

@Wolferos This should be the rest of the ships updated now.

I created a simple tool to parse through and apply some simple logic to the grouping.
https://github.com/sgerhardt/HeartsOfIronModTools

1. Fleets will be given the name of the largest task force in the fleet, with the text "Fleet" appended.

2. All navies that were in the same port are grouped in the fleet as task forces. It's possible to have fleets that are not in the same port, though that won't be the case here. I'm not sure what historical exceptions there would be to this.

### **Testing**
Spot checking a couple of nations in 1910 and 1914 should be sufficient since this was scripted out.
Ensure the ship names appear and ships are organized into fleets.

Let me know what you think.

