### PR TITLE
Russia civil war bugfix

### DIFF
--- a/mod/thegreatwar/events/WW1_Russia.txt
+++ b/mod/thegreatwar/events/WW1_Russia.txt
@@ -169,10 +169,6 @@ news_event = {
 					transfer_troops = yes
 				}
 				
-				declare_war_on = {
-		            type = annex_everything
-		            target = RUS
-		        }
 		        #every_state={
 				#	limit={
 				#		# SOV will get the same core as RUS
@@ -247,6 +243,12 @@ news_event = {
 					fascism = 0   
 					communism = 30 
 				}	
+			}
+			SOV = {
+			declare_war_on = {
+		            type = annex_everything
+		            target = RUS
+		        }
 			}
 		}
 	}


### PR DESCRIPTION
Second phase of Russian civil war does not fire properly due to order of effects, SOV tries to declare war on RUS before RUS is on the map again, easily fixed by moving the war declaration further down in the file