### PR TITLE
Create ww1_factions_l_german.yml

### DIFF
--- a/mod/thegreatwar/localisation/ww1_factions_l_german.yml
+++ b/mod/thegreatwar/localisation/ww1_factions_l_german.yml
@@ -1,0 +1,11 @@
+l_german:
+ entente:0 "Entente"
+ central_powers:0 "Mittelmächte"
+ anti_bulg_league:0 "Antibulgarisches Bündnis"
+ greater_builgaria:0 "Großbulgarisches Reich"
+ balkan_league:0 "Balkanbund"
+ white_movement:0 "Weiße Bewegung"
+ greater_benilux:0 "Großes Benelux Reich"
+ new_groot_nederland:0 "Großer Holländer"
+ caliphate:0 "Kalifat"
+ polishlithuaniancommonwealth_faction:0 "Polnisch-Litauisches Commonwealth"


### PR DESCRIPTION
For the following entries I could not find accurate historical references or if they are fictional as I do not know when/how a certain alliance is formed in game. If you happen to have references please let me know, same goes for which entries are fictional (if any).
For now, consider the following entries as best effort or placeholders:
"Anti Bulgarian league" -> no reference found (at least not for a league/alliance per se). As anti is used in German as well I translated it this way.
Greater Benelux -> no reference found. Added "Reich" at the End of the translation but depending on what is meant ingame this may be omitted or the whole term changed.
New Groot Nederland -> only reference found was https://nl.wikipedia.org/wiki/Grootneerlandisme but I do not know if this is the same.
Commonwealth -> best effort (the word is used in German, e.g. for the British Commonwealth and not translated). Again, I do not know the historical reference here to know if another term was used.