### PR TITLE
Fix character localisation errors

### DIFF
--- a/mod/thegreatwar/common/characters/GER.txt
+++ b/mod/thegreatwar/common/characters/GER.txt
@@ -560,8 +560,8 @@ characters = {
             legacy_id = 34054
         }
     }
-    GER_lothar_von_arnauld_de_la_perière = {
-        name = GER_lothar_von_arnauld_de_la_perière
+    GER_lothar_von_arnauld_de_la_periere = {
+        name = GER_lothar_von_arnauld_de_la_periere
         portraits = {
             army = {
                 large = "gfx/hoi4tgw_portraits/GER/navy_admirals/GER_von_arnauld_de_la_periere.dds"

--- a/mod/thegreatwar/history/countries/GER - Germany.txt
+++ b/mod/thegreatwar/history/countries/GER - Germany.txt
@@ -135,7 +135,7 @@ recruit_character = GER_von_mackensen
 #NAVY
 recruit_character = GER_franz_von_hipper
 recruit_character = GER_maximilian_von_spee
-recruit_character = GER_lothar_von_arnauld_de_la_perière
+recruit_character = GER_lothar_von_arnauld_de_la_periere
 recruit_character = GER_von_muller_k
 recruit_character = GER_curt_von_prittwitz_und_gaffron
 recruit_character = GER_henning_von_holtzendorff # Also Advisor

--- a/mod/thegreatwar/localisation/ww1_characters_l_english.yml
+++ b/mod/thegreatwar/localisation/ww1_characters_l_english.yml
@@ -2,7 +2,7 @@
  # AFG
  AFG_habibullah_khan:0 "Habibullah Khan"
  AFG_amanullah_khan:0 "Amanullah Khan"
- AFG_nadir_shah_mohamad：0 "Nadir Shah Mohamad"
+ AFG_nadir_shah_mohamad:0 "Nadir Shah Mohamad"
  AFG_muhammad_gul_mohmand:0 "Muhammad Gul Mohmand"
  AFG_ali_ahmad_khan:0 "Ali Ahmad Khan"
  AFG_kohandil_aziz:0 "Kohandil Aziz"
@@ -409,7 +409,7 @@
  GER_von_mackensen:0 "von Mackensen"
  GER_franz_von_hipper:0 "Franz von Hipper"
  GER_maximilian_von_spee:0 "Maximilian von Spee"
- GER_lothar_von_arnauld_de_la_perière:0 "Lothar von Arnauld de la Perière"
+ GER_lothar_von_arnauld_de_la_periere:0 "Lothar von Arnauld de la Perière"
  GER_von_muller_k:0 "Karl von Müller"
  GER_curt_von_prittwitz_und_gaffron:0 "Curt von Prittwitz und Gaffron"
  GER_friedrich_graf_von_baudissin:0 "Friedrich Graf von Baudissin"

--- a/mod/thegreatwar/localisation/ww1_characters_l_french.yml
+++ b/mod/thegreatwar/localisation/ww1_characters_l_french.yml
@@ -409,7 +409,7 @@
  GER_von_mackensen:0 "von Mackensen"
  GER_franz_von_hipper:0 "Franz von Hipper"
  GER_maximilian_von_spee:0 "Maximilian von Spee"
- GER_lothar_von_arnauld_de_la_perière:0 "Lothar von Arnauld de la Perière"
+ GER_lothar_von_arnauld_de_la_periere:0 "Lothar von Arnauld de la Perière"
  GER_von_muller_k:0 "Karl von Müller"
  GER_curt_von_prittwitz_und_gaffron:0 "Curt von Prittwitz und Gaffron"
  GER_friedrich_graf_von_baudissin:0 "Friedrich Graf von Baudissin"

--- a/mod/thegreatwar/localisation/ww1_ministers_l_english.yml
+++ b/mod/thegreatwar/localisation/ww1_ministers_l_english.yml
@@ -1,4 +1,4 @@
-﻿﻿l_english:
+﻿l_english:
  AFG_muhammad_sulaiman_khan:0 "Muhammad Sulaiman Khan"
  AFG_nadir_shah:0 "Nadir Shah"
  AFG_sardar_mahmud_tarzi:0 "Sardar Mahmud Tarzi"
@@ -2351,3 +2351,4 @@
  CYN_ding_zhipan:0 "Ding Zhipan"
  CYN_mi_zaiming:0 "Mi Zaiming"
  CYN_lu_han:0 "Lu Han"
+


### PR DESCRIPTION
This fixes a few issues that prevented the localisation of some character names:
* Space between colon and zero in yaml key `mod/thegreatwar/localisation/ww1_characters_l_english.yml` line 5
* Non-english character in localisation key `GER_lothar_von_arnauld_de_la_perière`
* `mod/thegreatwar/localisation/ww1_ministers_l_english.yml` somehow had two UTF-8 byte order marks