### PR TITLE
Fixed "SER_first_balkan" and "TUR_ww1_BalkanLeagueMenace" focuses

### DIFF
--- a/mod/thegreatwar/common/national_focus/ottoman.txt
+++ b/mod/thegreatwar/common/national_focus/ottoman.txt
@@ -941,36 +941,48 @@ focus_tree = {
 		icon = GFX_goal_generic_occupy_states_ongoing_war
 		available = {
 			date>1912.1.1
-			SER = {
-				exists = yes
-				is_in_faction_with = BUL
-			}
-			BUL = {
-				exists = yes
-				is_in_faction_with = SER
-			}
-			MTN = {
-				exists = yes
-				is_in_faction_with = SER
-			}
-			GRE = {
-				exists = yes
-				is_in_faction_with = SER
-			}
+			SER = {	
+				exists = yes	
+			}	
+			OR = {
+				SER = {
+					is_in_faction_with = BUL
+				}
+				SER = {
+					is_in_faction_with = MTN
+				}
+				SER = {
+					is_in_faction_with = GRE
+				}
+			}	
 		}
 		completion_reward = {
 			add_opinion_modifier = {
 				target = SER
 				modifier = HOI4TGW_Opinion_hostile_diplomatic_relations
 			}
-			add_opinion_modifier = {
-				target = MTN
-				modifier = HOI4TGW_Opinion_hostile_diplomatic_relations
-			}
-			add_opinion_modifier = {
-				target = GRE
-				modifier = HOI4TGW_Opinion_hostile_diplomatic_relations
-			}
+			if = {
+				limit = {
+					SER = {
+						is_in_faction_with = MTN
+					}
+				}
+				add_opinion_modifier = {
+					target = MTN
+					modifier = HOI4TGW_Opinion_hostile_diplomatic_relations	
+				}
+			}	
+			if = {
+				limit = {
+					SER = {
+						is_in_faction_with = GRE
+					}
+				}
+				add_opinion_modifier = {
+					target = GRE
+					modifier = HOI4TGW_Opinion_hostile_diplomatic_relations	
+				}
+			}	
 		}
 		ai_will_do = {
 			factor = 200

--- a/mod/thegreatwar/common/national_focus/serbia.txt
+++ b/mod/thegreatwar/common/national_focus/serbia.txt
@@ -704,11 +704,20 @@ focus_tree = {
 		icon = GFX_goal_generic_military_deal
 		available = {
 			date > 1912.3.1
-			184 = {
-				owner = {
-					original_tag = TUR
+			OR = {
+				TUR = {
+					owns_state = 184 
+				}	
+				TUR = {
+					owns_state = 760
 				}
-			}
+				TUR = {
+					owns_state = 761
+				}
+				TUR = {
+					owns_state = 788
+				}	
+			}	
 			SER = {
 				exists = yes
 				is_puppet = no


### PR DESCRIPTION
### Fixed "SER_first_balkan" focus

Serbia will not be able to complete the "SER_first_balkan" focus if Turkey returns the states it occupied to Greece. These are states 731, 184, 757, 756, 790, 164. This scenario is possible when playing as Turkey, when, in order to avoid the Balkan War, the player sacrifices part of the European territories (Thrace, Aegean Macedonia and the Aegean Islands), but the rest remains under his control (Albania, North Macedonia, East Montenegro, South Serbia and others).

This is possible because one of the conditions for completing the "SER_first_balkan" focus is the presence of state 184 (Thrace) as part of the Ottoman Empire. If you transfer it to Greece, the condition will no longer be met.

To fix this, need to change this condition. I propose to make the presence of at least one of the following states within the Ottoman Empire a necessary condition for the start of the Balkan War: 184 (Thrace), 760 (South Serbia), 761 (East Montenegro), 788 (East Rumelia). In this case, Turkey will not be able to avoid war, no matter which states it voluntarily returns.


### Fixed "TUR_ww1_BalkanLeagueMenace" focus

The Ottoman Empire will not be able to complete the "TUR_ww1_BalkanLeagueMenace" focus if Bulgaria, Montenegro or Greece refuse to join the Balkan League. If the Ottoman Empire fails this focus, it will then be unable to complete the next focus "TUR_ww1_SecondBalkanWarOpportunity" and join the Second Balkan War.

This is possible because one of the conditions for completing the "TUR_ww1_BalkanLeagueMenace" focus is the presence of all of the above countries in the alliance. If at least one country refuses to join the Balkan League (even Montenegro), then the condition will no longer be met.

To fix this, you need to change this condition. A necessary condition for performing the trick, I propose to make the presence in the Balkan League of at least one of the above countries (plus Serbia as a founder), so that either Bulgaria is in an alliance with Serbia, or Montenegro, or Greece.

In addition, since this condition will now be met even if not all Balkan countries are included in the Balkan League, it makes sense to use the "hostile diplomatic relations" modifier only in relation to those countries that have entered into an alliance with Serbia. If Greece (or Montenegro) is not a member of the alliance, then it is somehow not logical for the Ottoman Empire to worsen diplomatic relations with it (Bulgaria is not on the list, relations with it are worsening in the previous focus, "TUR_ww1_AntiBulgaria").