### PR TITLE
Handling events related to unusual player behavior during the Balkan Wars

### DIFF
--- a/mod/thegreatwar/events/WW1_Firstbalkan.txt
+++ b/mod/thegreatwar/events/WW1_Firstbalkan.txt
@@ -215,6 +215,22 @@ country_event = {
 						is_in_faction_with = MTN
 					}
 				}
+				# Greece participates in a war with Turkey only if Turkey did not return the occupied states (731, 184, 756, 757, 790) to it before the start of the war
+				TUR = {
+					owns_state = 731 
+				}	
+				TUR = {
+					owns_state = 184 
+				}	
+				TUR = {
+					owns_state = 756
+				}
+				TUR = {
+					owns_state = 757
+				}
+				TUR = {
+					owns_state = 790
+				}
 			}
 			GRE = {
 				create_wargoal = {
@@ -232,6 +248,29 @@ country_event = {
 				}
 			}
 		}
+		# If Turkey returned Greece to its national states before the start of the war, then Greece leaves the Balkan League and does not participate in the war
+		if = {
+			limit = {
+				GRE = {
+					owns_state = 731 
+				}	
+				GRE = {
+					owns_state = 184 
+				}	
+				GRE = {
+					owns_state = 756
+				}
+				GRE = {
+					owns_state = 757
+				}
+				GRE = {
+					owns_state = 790
+				}				
+			}
+			SER = {
+				remove_from_faction = GRE
+			}
+		}		
 		# Montenegro
 		if = {
 			limit = {
@@ -337,38 +376,119 @@ country_event = {
 		ai_chance = {
 			factor = 100
 		}
-		GRE = {
-			white_peace = TUR
-		}
-		GRE = {
-			transfer_state = 731
-			transfer_state = 758
-			add_state_core = 731
-			add_state_core = 758
-			diplomatic_relation = {
-				country = TUR
-				relation = non_aggression_pact
-			}
-		}
-		BUL = {
-			white_peace = TUR
-		}		
-		BUL = {
-			transfer_state = 184
-			transfer_state = 756
-			transfer_state = 757
-			transfer_state = 788
-			transfer_state = 759
-			add_state_core = 184
-			add_state_core = 756
-			add_state_core = 757
-			add_state_core = 788
-			add_state_core = 759
-			diplomatic_relation = {
-				country = TUR
-				relation = non_aggression_pact
-			}
-		}
+		# If Greece did not participate in the First Balkan War, then region 758 (Central Epirus) will not go to it, but to Albania
+		if = {
+			limit = {
+				NOT = {
+					GRE = {
+						has_war_with = TUR
+					}
+				}
+			}	
+			ALB = {
+				transfer_state = 758
+				add_state_core = 758
+			}		
+		}	
+		# If Greece did not participate in the First Balkan War, then region 731 (West Macedonia) will not go to it, but to Bulgaria
+		# However, if region 731 (West Macedonia) already belongs to Greece (it was transferred by Turkey before the start of the war), then it remains with Greece		
+		if = {
+			limit = {
+				NOT = {
+					GRE = {
+						has_war_with = TUR
+					}
+					GRE = {
+						owns_state = 731 
+					}
+				}
+			}	
+			BUL = {
+				transfer_state = 731
+				add_state_core = 731
+			}			
+		}			
+		# If Greece participate in the First Balkan War, then region 731 (West Macedonia), 758 (Central Epirus) and 790 (North Aegean islands) will go to it
+		if = {
+			limit = {
+				GRE = {
+					has_war_with = TUR
+				}
+			}	
+			GRE = {
+				white_peace = TUR
+				transfer_state = 731
+				transfer_state = 758
+				transfer_state = 790
+				add_state_core = 731
+				add_state_core = 758
+				add_state_core = 790
+				diplomatic_relation = {
+					country = TUR
+					relation = non_aggression_pact
+				}
+			}	
+		}	
+		# If Bulgaria did not participate in the First Balkan War, then regions 184 (East Macedonia) and 759 (Nordeastern Macedonia) will not go to it, but to Greece and Serbia
+		if = {
+			limit = {
+				NOT = {
+					BUL = {
+						has_war_with = TUR
+					}
+				}	
+			}		
+			GRE = {
+				transfer_state = 184
+				add_state_core = 184
+			}	
+			SER = {
+				transfer_state = 759
+				add_state_core = 759
+			}			
+		}	
+		# If Bulgaria participate in the First Balkan War, then regions 788 (East Rumelia) and 759 (Nordeastern Macedonia) will go to it
+		if = {
+			limit = {
+				BUL = {
+					has_war_with = TUR
+				}
+			}		
+			BUL = {
+				white_peace = TUR
+				transfer_state = 788
+				transfer_state = 759
+				add_state_core = 788
+				add_state_core = 759
+				diplomatic_relation = {
+					country = TUR
+					relation = non_aggression_pact
+				}
+			}	
+		}	
+		# If Turkey returned Greece to its national states (184, 756, 757) before the start of the war, then it remains with Greece and not transferred to Bulgaria
+		if = {
+			limit = {
+				TUR = {
+					owns_state = 184 
+				}	
+				TUR = {
+					owns_state = 756
+				}
+				TUR = {
+					owns_state = 757
+				}	
+			}		
+			BUL = {
+				transfer_state = 184
+				transfer_state = 756
+				transfer_state = 757
+				add_state_core = 184
+				add_state_core = 756
+				add_state_core = 757
+			}	
+		}	
+
 		MTN = {
 			white_peace = TUR
 		}		

--- a/mod/thegreatwar/events/WW1_Secondbalkan.txt
+++ b/mod/thegreatwar/events/WW1_Secondbalkan.txt
@@ -20,7 +20,15 @@ country_event = {
 			# Factions
 			SER = {
 				create_faction = anti_bulg_league
-				add_to_faction = GRE
+				# If Greece did not participate in the First Balkan War or left the alliance before the Second Balkan War, it will not invite to the Anti-Bulgarian League
+				if = {
+					limit = {
+						GRE = {
+							is_in_faction = yes				# Check for participation of Greece in the Balkan League
+						}
+					}
+					add_to_faction = GRE	
+				}
 				add_to_faction = MTN
 			}
 			BUL = {
@@ -42,11 +50,19 @@ country_event = {
 			    set_country_flag = kis_secondbalkanwar_start
 			}
 
-			GRE = {
-			    add_to_war = {
-		            targeted_alliance = SER enemy = BUL
-		        }
-			}
+			# If Greece did not participate in the First Balkan War or left the Anti-Bulgarian League before the Second Balkan War, it will not participate in the Second Balkan War
+			if = {
+				limit = {
+					GRE = {
+						is_in_faction_with = SER				# Check for participation of Greece in the Anti-Bulgarian League
+					}
+				}
+				GRE = {
+					add_to_war = {
+						targeted_alliance = SER enemy = BUL
+					}
+				}
+			}	
 			MTN = {
 			    add_to_war = {
 		            targeted_alliance = SER enemy = BUL


### PR DESCRIPTION
If you start the game in observer mode, the Balkan Wars will take place in historical mode: Serbia, Montenegro, Bulgaria and Greece will first attack the Ottoman Empire together (BW1), and then Serbia, Montenegro, Greece and the Ottoman Empire will fight with Bulgaria (BW2). But what if the player decides to add variety to the game and makes decisions that differ from the events of world history?

## Events of the First Balkan War:

### Example 1:
The player plays as the Ottoman Empire and decides to give Greece its national states: Macedonia and Thrace, as well as the Aegean Islands (the Dodecanese is excluded from the list, since there is a possibility that by the time the decision is made it will belong to Italy). In this case, the reason for the Greeks to fight the Turks disappears: all occupied national regions are transferred to Greece, and Central Epirus, which remains with the Ottoman Empire, is not a national region of Greece. It is logical that Greece will refuse war in this case. And, accordingly, there will be no reason to be in the Balkan League.

### Example 2:
The player plays for Greece and refuses to join the Balkan League, or leaves it before the First Balkan War. In this case, after the end of the war, it will turn out that Central Epirus (state 758) and the western part of Aegean Macedonia (state 731) will be ownerless. In this case, it is proposed to give state 758 to the newly created Albania (as an alternative, Serbia can also be given, but definitely not to Bulgaria), and state 731 to Bulgaria.

Remark: in example 1, Greece is also not participating in the war, but only state 758 will remain ownerless, since state 731 was already transferred to Greece by the Ottoman Empire.

### Example 3:
The player plays for Bulgaria and refuses to join the Balkan League, or leaves it before the First Balkan War. In this case, after the end of the war, it will turn out that the eastern part of Aegean Macedonia (state 184) and the eastern part of present-day North Macedonia (state 759) will be ownerless. In this case, it is proposed to give state 184 to Greece, and state 759 to Serbia (as was done only after the Second Balkan War).

## Events of the Second Balkan War:

### Example 4:
The player plays as Greece and does not participate in the First Balkan War (examples 1 and 2), or participates but withdraws from the Balkan League before the Second Balkan War. In this case, since Greece will not be a member of the Balkan League by the start of the Second Balkan War, it is logical not to invite Greece to the Anti-Bulgarian League, and then Greece will not participate in the Second Balkan War.

## Not an example, but a fix:
According to historical events, the Aegean Islands (state 790) [were transferred to Greece](https://en.wikipedia.org/wiki/North_Aegean_islands) after the First Balkan War.