### PR TITLE
hotfix/fix focus SOV_interwar_french_nodeal

### DIFF
--- a/mod/thegreatwar/history/units/SOV_1919_renf.txt
+++ b/mod/thegreatwar/history/units/SOV_1919_renf.txt
@@ -1,3 +1,17 @@
+###################################################################
+division_template = {
+	name = "Strelkovaya Diviziya"
+	division_names_group = SOV_INF_01
+	regiments = {
+		infantry = { x = 0 y = 0 }
+		infantry = { x = 0 y = 1 }
+		infantry = { x = 1 y = 0 }
+		infantry = { x = 1 y = 1 }
+	}
+	# priority = 2
+}
+###################################################################
+
 instant_effect = {
 	add_manpower = 120000
 }


### PR DESCRIPTION
Fiixes a game crash while loading the fle sov_1919_renf due that division template was not defined.

File is loaded on the SOV focus SOV_interwar_french_nodeal


Error crash: 
[14:14:41][1921.03.19.01][persistent.cpp:45]: Error: "Malformed token: Strelkovaya Diviziya, near line: 12" in file: "history/units/SOV_1919_renf.txt" near line: 12

