### PR TITLE
Handling events related to the World War I

### DIFF
--- a/mod/thegreatwar/events/WW1_AlternativeHisotry.txt
+++ b/mod/thegreatwar/events/WW1_AlternativeHisotry.txt
@@ -117,10 +117,29 @@ country_event = {
 				days = 1
 				id = ww1_alternativehistory.4
 			}
-			RUS = {
-				country_event = {
-					days = 1
-					id = ww1_alternativehistory.6
+			# Russia can help Serbia only if it itself is not a member of the Central Powers
+			if = {
+				limit = {
+					RUS = {
+						NOT = {
+							is_in_faction_with = GER
+						}
+					}
+				}
+				RUS = {
+					country_event = {
+						days = 1
+						id = ww1_alternativehistory.6
+					}
+				}
+			}
+			# If Russia is a member of the Central Powers, then France can help Serbia without Russia's decision.
+			else = {
+				FRA = {
+					country_event = {
+						days = 1
+						id = ww1_alternativehistory.8
+					}
 				}
 			}
 			set_global_flag = kis_alternativehistory_2_serbia_refuses
@@ -132,6 +151,22 @@ country_event = {
 						has_global_flag = kis_firstbalkanwar_victory
 					}
 				}
+				# Each country at war with Turkey (Serbia, Montenegro, Greece and Bulgaria), in the event of a forced end to the war
+				# (attack of Austria-Hungary on Serbia, ww1_alternativehistory.1)
+				# receives the territories of Turkey that it managed to capture
+				every_country = {
+					limit = {
+						has_war_with = TUR
+					}
+					every_controlled_state = {
+						limit = {
+							is_owned_by = TUR
+						}
+						transfer_state_to = PREV
+						#add_core_of = PREV
+					}
+				}
+
 				SER = {
 					white_peace = TUR
 					remove_from_faction = MTN


### PR DESCRIPTION
### Russia joined the Central Powers

In the scenario where Russia joins the Central Powers, some events look strange.

![WWI-1](https://github.com/user-attachments/assets/105609e4-3980-454e-a062-bfbcedee65ea)

If the Balkan War is still going on, and this prevents Austria from declaring war on Serbia, then the Balkan War is forced to end, according to the mod's conditions.

![WWI-2](https://github.com/user-attachments/assets/2fd03c93-e371-4a89-9d47-7461b7a34808)

Serbia and the Ottoman Empire sign a peace (we will return to its conditions later).

![WWI-3](https://github.com/user-attachments/assets/875ec810-378a-4175-b250-51c254b230fb)

Austria-Hungary declares war on Serbia. So far, so logical.

![WWI-4](https://github.com/user-attachments/assets/8db652cf-6a15-4d9a-934c-7268ebd085ba)

And then... suddenly Russia is asked to declare war on Austria-Hungary, despite the fact that these two countries are in the same alliance! Well, let's try.

![WWI-5](https://github.com/user-attachments/assets/762c573f-f537-43dd-97cf-bbbfd455eae5)

The whole world believed in our intentions. Read the world news: Russia declared war on Austria-Hungary!

![WWI-6](https://github.com/user-attachments/assets/449fbf34-2920-49d0-927c-b38179926856)

You will never believe what happened next! The bonds of alliance prove stronger! Austria-Hungary not only refuses to fight Russia, it also offers Russia to join the war with Serbia! Well, let's agree to this too.

![WWI-7](https://github.com/user-attachments/assets/565cb84d-4deb-48e9-8ae3-d02131762718)

And only now Russia enters the war, and on the side of Austria-Hungary. Who would have thought!

![WWI-8](https://github.com/user-attachments/assets/e8c86e46-862a-48d2-a0b1-f2090e478d06)


To avoid such a strange situation, we are making changes to the mod:

- Russia can help Serbia only if it itself is not a member of the Central Powers
- If Russia is a member of the Central Powers, then France can help Serbia without Russia's decision.

### The Balkan League almost defeated the Ottoman Empire, but...

Notice how much land the Ottoman Empire loses in the war with the Balkan Union. Albania, Montenegro, Eastern Rumelia, half of Macedonia... Just a little more, and...

![image](https://github.com/user-attachments/assets/864a90d5-2af7-49e9-92cc-f1868d59eca1)

But... then Austria-Hungary appears and declares: "It's my turn to fight Serbia!" And voila, the Ottoman Empire instantly regains all its lost lands.

![image](https://github.com/user-attachments/assets/a887ebe4-b6e6-43e9-b5d9-a38b7113d4a0)


To avoid such a situation, we are making changes to the mod:

- Each country at war with Turkey (Serbia, Montenegro, Greece and Bulgaria), in the event of a forced end to the war (attack of Austria-Hungary on Serbia, ww1_alternativehistory.1) receives the territories of Turkey that it managed to capture.


**That's all Folks!**